### PR TITLE
return a better error when uuid is not found

### DIFF
--- a/drift/exceptions.py
+++ b/drift/exceptions.py
@@ -15,3 +15,12 @@ class HTTPError(Exception):
         super(HTTPError, self).__init__()
         self.message = message
         self.status_code = status_code
+
+
+class SystemNotReturned(Exception):
+    def __init__(self, message):
+        """
+        Raise this exception if a system was not returned by inventory service
+        """
+        super(SystemNotReturned, self).__init__()
+        self.message = message

--- a/drift/inventory_service_interface.py
+++ b/drift/inventory_service_interface.py
@@ -3,6 +3,8 @@ import os
 import requests
 from urllib.parse import urljoin
 
+from drift.exceptions import SystemNotReturned
+
 AUTH_HEADER_NAME = 'X-RH-IDENTITY'
 INVENTORY_SVC_HOSTNAME = os.getenv('INVENTORY_SVC_URL', "http://inventory_svc_url_is_not_set")
 INVENTORY_SVC_HOSTS_ENDPOINT = '/r/insights/platform/inventory/api/v1/hosts/%s'
@@ -20,6 +22,8 @@ def fetch_hosts(host_ids, service_auth_key):
     for host_id in host_ids:
         response = requests.get(inventory_service_location % host_id, headers=auth_header)
         result = json.loads(response.text)
+        if result['count'] == 0:
+            raise SystemNotReturned("System %s not available to display" % host_id)
         hosts.append(result['results'][0])
 
     # TODO: see if we need to ensure we got back the number of hosts we expected

--- a/drift/views/v0.py
+++ b/drift/views/v0.py
@@ -5,7 +5,7 @@ import json
 import base64
 
 from drift import info_parser
-from drift.exceptions import HTTPError
+from drift.exceptions import HTTPError, SystemNotReturned
 from drift.inventory_service_interface import fetch_hosts, get_key_from_headers
 
 APP_URL_PREFIX = "/r/insights/platform/drift"
@@ -25,8 +25,11 @@ def compare():
     if auth_key is None:
         raise HTTPError(HTTPStatus.BAD_REQUEST, message="auth header not specified")
 
-    comparisons = info_parser.build_comparisons(fetch_hosts(host_ids, auth_key))
-    return jsonify(comparisons)
+    try:
+        comparisons = info_parser.build_comparisons(fetch_hosts(host_ids, auth_key))
+        return jsonify(comparisons)
+    except SystemNotReturned as error:
+        raise HTTPError(HTTPStatus.BAD_REQUEST, message=error.message)
 
 
 @section.route("/status")

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -64,3 +64,13 @@ HOST_TEMPLATE = '''
       "tags": [],
       "updated": "2018-12-31T12:00:00.000000Z"
     }]}'''
+
+HOST_NOT_FOUND_TEMPLATE = '''
+    {
+      "count": 0,
+      "page": 1,
+      "per_page": 50,
+      "results": [],
+      "total": 0
+    }
+    '''

--- a/tests/test_inventory_service_interface.py
+++ b/tests/test_inventory_service_interface.py
@@ -1,5 +1,7 @@
-from drift import inventory_service_interface
 import responses
+
+from drift import inventory_service_interface
+from drift.exceptions import SystemNotReturned
 
 import unittest
 
@@ -12,6 +14,12 @@ class InventoryServiceTests(unittest.TestCase):
         url_template = "http://%s/r/insights/platform/inventory/api/v1/hosts/%s"
         responses.add(responses.GET, url_template % (service_hostname, host_uuid),
                       body=fixtures.HOST_TEMPLATE % host_uuid, status=200,
+                      content_type='application/json')
+
+    def _create_response_for_missing_host(self, service_hostname, host_uuid):
+        url_template = "http://%s/r/insights/platform/inventory/api/v1/hosts/%s"
+        responses.add(responses.GET, url_template % (service_hostname, host_uuid),
+                      body=fixtures.HOST_NOT_FOUND_TEMPLATE, status=200,
                       content_type='application/json')
 
     @responses.activate
@@ -27,3 +35,22 @@ class InventoryServiceTests(unittest.TestCase):
 
         found_host_ids = {host['id'] for host in hosts}
         self.assertSetEqual(found_host_ids, set(hosts_to_fetch))
+
+    @responses.activate
+    def test_fetch_hosts_missing_host(self):
+        hosts_to_fetch = ['243926fa-262f-11e9-a632-c85b761454fa',
+                          '264fb5b2-262f-11e9-9b12-c85b761454fa',
+                          '269a3da8-262f-11e9-8ee5-c85b761454fa']
+
+        self._create_response_for_host('inventory_svc_url_is_not_set',
+                                       '243926fa-262f-11e9-a632-c85b761454fa')
+        self._create_response_for_missing_host('inventory_svc_url_is_not_set',
+                                               '264fb5b2-262f-11e9-9b12-c85b761454fa')
+        self._create_response_for_host('inventory_svc_url_is_not_set',
+                                       '269a3da8-262f-11e9-8ee5-c85b761454fa')
+
+        with self.assertRaises(SystemNotReturned) as cm:
+            inventory_service_interface.fetch_hosts(hosts_to_fetch, "my-auth-key")
+
+        self.assertEqual(cm.exception.message,
+                         "System 264fb5b2-262f-11e9-9b12-c85b761454fa not available to display")

--- a/tests/test_v0_api.py
+++ b/tests/test_v0_api.py
@@ -1,7 +1,9 @@
-from drift import app
 import logging
 import json
 from io import StringIO
+
+from drift import app
+from drift.exceptions import SystemNotReturned
 
 from . import fixtures
 import mock
@@ -38,6 +40,15 @@ class ApiTests(unittest.TestCase):
                                    "host_ids[]=11b3cbce-25a9-11e9-8457-c85b761454fa",
                                    headers=fixtures.AUTH_HEADER)
         self.assertEqual(response.status_code, 200)
+
+    @mock.patch('drift.views.v0.fetch_hosts')
+    def test_compare_api_missing_system_uuid(self, mock_fetch_hosts):
+        mock_fetch_hosts.side_effect = SystemNotReturned("oops")
+        response = self.client.get("r/insights/platform/drift/v0/compare?"
+                                   "host_ids[]=d6bba69a-25a8-11e9-81b8-c85b761454fa"
+                                   "host_ids[]=11b3cbce-25a9-11e9-8457-c85b761454fa",
+                                   headers=fixtures.AUTH_HEADER)
+        self.assertEqual(response.status_code, 400)
 
 
 class DebugLoggingApiTests(unittest.TestCase):


### PR DESCRIPTION
Previously, if you requested a UUID that was not found by inventory service,
you'd get a 500 error.

Instead, return a 400 error with a more helpful message.