### PR TITLE
rename 'compare' to 'comparison_report'

### DIFF
--- a/drift/views/v0.py
+++ b/drift/views/v0.py
@@ -14,8 +14,8 @@ API_VERSION_PREFIX = "/v0"
 section = Blueprint('v0', __name__, url_prefix=APP_URL_PREFIX + API_VERSION_PREFIX)
 
 
-@section.route("/compare")
-def compare():
+@section.route("/comparison_report")
+def comparison_report():
     system_ids = request.args.getlist('system_ids[]')
     auth_key = get_key_from_headers(request.headers)
 

--- a/tests/test_v0_api.py
+++ b/tests/test_v0_api.py
@@ -22,12 +22,12 @@ class ApiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(json.loads(response.data), {'status': 'running'})
 
-    def test_compare_api_no_args_or_header(self):
-        response = self.client.get("r/insights/platform/drift/v0/compare")
+    def test_comparison_report_api_no_args_or_header(self):
+        response = self.client.get("r/insights/platform/drift/v0/comparison_report")
         self.assertEqual(response.status_code, 400)
 
-    def test_compare_api_no_header(self):
-        response = self.client.get("r/insights/platform/drift/v0/compare?"
+    def test_comparison_report_api_no_header(self):
+        response = self.client.get("r/insights/platform/drift/v0/comparison_report?"
                                    "system_ids[]=d6bba69a-25a8-11e9-81b8-c85b761454fa"
                                    "system_ids[]=11b3cbce-25a9-11e9-8457-c85b761454fa")
         self.assertEqual(response.status_code, 400)
@@ -40,18 +40,18 @@ class ApiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
 
     @mock.patch('drift.views.v0.fetch_systems')
-    def test_compare_api(self, mock_fetch_systems):
+    def test_comparison_report_api(self, mock_fetch_systems):
         mock_fetch_systems.return_value = fixtures.FETCH_SYSTEMS_RESULT
-        response = self.client.get("r/insights/platform/drift/v0/compare?"
+        response = self.client.get("r/insights/platform/drift/v0/comparison_report?"
                                    "system_ids[]=d6bba69a-25a8-11e9-81b8-c85b761454fa"
                                    "system_ids[]=11b3cbce-25a9-11e9-8457-c85b761454fa",
                                    headers=fixtures.AUTH_HEADER)
         self.assertEqual(response.status_code, 200)
 
     @mock.patch('drift.views.v0.fetch_systems')
-    def test_compare_api_missing_system_uuid(self, mock_fetch_systems):
+    def test_comparison_report_api_missing_system_uuid(self, mock_fetch_systems):
         mock_fetch_systems.side_effect = SystemNotReturned("oops")
-        response = self.client.get("r/insights/platform/drift/v0/compare?"
+        response = self.client.get("r/insights/platform/drift/v0/comparison_report?"
                                    "system_ids[]=d6bba69a-25a8-11e9-81b8-c85b761454fa"
                                    "system_ids[]=11b3cbce-25a9-11e9-8457-c85b761454fa",
                                    headers=fixtures.AUTH_HEADER)


### PR DESCRIPTION
It makes more sense to "get a comparison report", thus the latter is more
resty.