### PR TITLE
fetch all UUIDs at the same time from inventory svc

### DIFF
--- a/drift/inventory_service_interface.py
+++ b/drift/inventory_service_interface.py
@@ -7,7 +7,9 @@ from drift.exceptions import SystemNotReturned
 
 AUTH_HEADER_NAME = 'X-RH-IDENTITY'
 INVENTORY_SVC_HOSTNAME = os.getenv('INVENTORY_SVC_URL', "http://inventory_svc_url_is_not_set")
-INVENTORY_SVC_HOSTS_ENDPOINT = '/r/insights/platform/inventory/api/v1/hosts/%s'
+INVENTORY_SVC_HOSTS_ENDPOINT = '/r/insights/platform/inventory/api/v1/hosts/%s?per_page=%s'
+
+MAX_UUID_COUNT = 20
 
 
 def get_key_from_headers(incoming_headers):
@@ -15,16 +17,18 @@ def get_key_from_headers(incoming_headers):
 
 
 def fetch_systems(system_ids, service_auth_key):
+    if len(system_ids) > MAX_UUID_COUNT:
+        raise SystemNotReturned("Too many systems requested, limit is %s" % MAX_UUID_COUNT)
+
     auth_header = {AUTH_HEADER_NAME: service_auth_key}
-    systems = []
 
     inventory_service_location = urljoin(INVENTORY_SVC_HOSTNAME, INVENTORY_SVC_HOSTS_ENDPOINT)
-    for system_id in system_ids:
-        response = requests.get(inventory_service_location % system_id, headers=auth_header)
-        result = json.loads(response.text)
-        if result['count'] == 0:
-            raise SystemNotReturned("System %s not available to display" % system_id)
-        systems.append(result['results'][0])
+    response = requests.get(inventory_service_location % (','.join(system_ids), MAX_UUID_COUNT),
+                            headers=auth_header)
+    result = json.loads(response.text)
 
-    # TODO: see if we need to ensure we got back the number of systems we expected
-    return systems
+    if result['count'] < len(system_ids):
+        system_ids_returned = {system['id'] for system in result['results']}
+        missing_ids = set(system_ids) - system_ids_returned
+        raise SystemNotReturned("System(s) %s not available to display" % ','.join(missing_ids))
+    return result['results']

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -33,9 +33,9 @@ FETCH_SYSTEMS_RESULT = [
       "updated": "2019-01-31T14:00:00.500000Z"
     }]
 
-SYSTEM_TEMPLATE = '''
+SYSTEMS_TEMPLATE = '''
     {
-      "count": 1,
+      "count": 2,
       "page": 1,
       "per_page": 50,
       "results": [
@@ -51,7 +51,7 @@ SYSTEM_TEMPLATE = '''
         }
       ],
       "fqdn": "system.example.com",
-      "id": "%s",
+      "id": "243926fa-262f-11e9-a632-c85b761454fa",
       "insights_id": "TEST-ID00-0000-0000",
       "ip_addresses": [
         "10.0.0.1",
@@ -63,7 +63,33 @@ SYSTEM_TEMPLATE = '''
       "subscription_manager_id": "1234FAKE1234",
       "tags": [],
       "updated": "2018-12-31T12:00:00.000000Z"
-    }]}'''
+    },
+    {
+      "account": "1234567",
+      "bios_uuid": "ec43976c263411e9bcf0c85b761454fa",
+      "created": "2018-12-01T12:00:00.000000Z",
+      "display_name": "system2.example.com",
+      "facts": [
+        {
+          "facts": {},
+          "namespace": "string"
+        }
+      ],
+      "fqdn": "system2.example.com",
+      "id": "264fb5b2-262f-11e9-9b12-c85b761454fa",
+      "insights_id": "TEST-ID22-2222-2222",
+      "ip_addresses": [
+        "10.0.0.3",
+        "10.0.0.4"
+      ],
+      "mac_addresses": [
+        "ec2:00:d0:c8:00:01"
+      ],
+      "subscription_manager_id": "2222FAKE2222",
+      "tags": [],
+      "updated": "2018-12-31T12:00:00.000000Z"
+    }
+    ]}'''
 
 SYSTEM_NOT_FOUND_TEMPLATE = '''
     {

--- a/tests/test_inventory_service_interface.py
+++ b/tests/test_inventory_service_interface.py
@@ -1,35 +1,27 @@
 import responses
+import string
+import unittest
 
 from drift import inventory_service_interface
 from drift.exceptions import SystemNotReturned
-
-import unittest
-
 from . import fixtures
 
 
 class InventoryServiceTests(unittest.TestCase):
 
-    def _create_response_for_system(self, service_hostname, system_uuid):
+    def _create_response_for_systems(self, service_hostname, system_uuids):
         url_template = "http://%s/r/insights/platform/inventory/api/v1/hosts/%s"
-        responses.add(responses.GET, url_template % (service_hostname, system_uuid),
-                      body=fixtures.SYSTEM_TEMPLATE % system_uuid, status=200,
-                      content_type='application/json')
-
-    def _create_response_for_missing_system(self, service_hostname, system_uuid):
-        url_template = "http://%s/r/insights/platform/inventory/api/v1/hosts/%s"
-        responses.add(responses.GET, url_template % (service_hostname, system_uuid),
-                      body=fixtures.SYSTEM_NOT_FOUND_TEMPLATE, status=200,
+        responses.add(responses.GET, url_template % (service_hostname, system_uuids),
+                      body=fixtures.SYSTEMS_TEMPLATE, status=200,
                       content_type='application/json')
 
     @responses.activate
     def test_fetch_systems(self):
         systems_to_fetch = ['243926fa-262f-11e9-a632-c85b761454fa',
-                            '264fb5b2-262f-11e9-9b12-c85b761454fa',
-                            '269a3da8-262f-11e9-8ee5-c85b761454fa']
+                            '264fb5b2-262f-11e9-9b12-c85b761454fa']
 
-        for system_id in systems_to_fetch:
-            self._create_response_for_system('inventory_svc_url_is_not_set', system_id)
+        self._create_response_for_systems('inventory_svc_url_is_not_set',
+                                          ','.join(systems_to_fetch))
 
         systems = inventory_service_interface.fetch_systems(systems_to_fetch, "my-auth-key")
 
@@ -42,15 +34,20 @@ class InventoryServiceTests(unittest.TestCase):
                             '264fb5b2-262f-11e9-9b12-c85b761454fa',
                             '269a3da8-262f-11e9-8ee5-c85b761454fa']
 
-        self._create_response_for_system('inventory_svc_url_is_not_set',
-                                         '243926fa-262f-11e9-a632-c85b761454fa')
-        self._create_response_for_missing_system('inventory_svc_url_is_not_set',
-                                                 '264fb5b2-262f-11e9-9b12-c85b761454fa')
-        self._create_response_for_system('inventory_svc_url_is_not_set',
-                                         '269a3da8-262f-11e9-8ee5-c85b761454fa')
+        self._create_response_for_systems('inventory_svc_url_is_not_set',
+                                          ','.join(systems_to_fetch))
 
         with self.assertRaises(SystemNotReturned) as cm:
             inventory_service_interface.fetch_systems(systems_to_fetch, "my-auth-key")
 
         self.assertEqual(cm.exception.message,
-                         "System 264fb5b2-262f-11e9-9b12-c85b761454fa not available to display")
+                         "System(s) 269a3da8-262f-11e9-8ee5-c85b761454fa not available to display")
+
+    def test_fetch_too_many_systems(self):
+        systems_to_fetch = list(string.ascii_lowercase)
+
+        with self.assertRaises(SystemNotReturned) as cm:
+            inventory_service_interface.fetch_systems(systems_to_fetch, "my-auth-key")
+
+        self.assertEqual(cm.exception.message,
+                         "Too many systems requested, limit is 20")


### PR DESCRIPTION
This currently caps the fetch at one page worth of info. You'll get a 400 error
if you ask for more than 20.