### PR TITLE
check if 'account' is missing from identity

### DIFF
--- a/drift/views/v0.py
+++ b/drift/views/v0.py
@@ -38,6 +38,17 @@ def status():
 
 
 @section.before_app_request
+def ensure_account_number():
+    auth_key = get_key_from_headers(request.headers)
+    if auth_key:
+        identity = json.loads(base64.b64decode(auth_key))['identity']
+        if 'account_number' not in identity:
+            current_app.logger.debug("account number not found on identity token %s" % auth_key)
+            raise HTTPError(HTTPStatus.BAD_REQUEST,
+                            message="account number not found on identity token")
+
+
+@section.before_app_request
 def log_username():
     if current_app.logger.level == logging.DEBUG:
         auth_key = get_key_from_headers(request.headers)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,3 +1,26 @@
+"""
+decoded AUTH_HEADER (newlines added for readability):
+{
+    "identity": {
+        "account_number": "1234",
+        "internal": {
+            "org_id": "5678"
+        },
+        "type": "User",
+        "user": {
+            "email": "test@example.com",
+            "first_name": "Firstname",
+            "is_active": true,
+            "is_internal": true,
+            "is_org_admin": false,
+            "last_name": "Lastname",
+            "locale": "en_US",
+            "username": "test_username"
+        }
+    }
+}
+"""
+
 AUTH_HEADER = {'X-RH-IDENTITY': 'eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6Ij'
                                 'EyMzQiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNl'
                                 'cm5hbWUiOiJ0ZXN0X3VzZXJuYW1lIiwiZW1haWwiOi'
@@ -7,6 +30,35 @@ AUTH_HEADER = {'X-RH-IDENTITY': 'eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6Ij'
                                 'aW4iOmZhbHNlLCJpc19pbnRlcm5hbCI6dHJ1ZSwibG'
                                 '9jYWxlIjoiZW5fVVMifSwiaW50ZXJuYWwiOnsib3Jn'
                                 'X2lkIjoiNTY3OCJ9fX0KCg=='}
+"""
+decoded AUTH_HEADER_NO_ACCT (newlines added for readablity):
+{
+    "identity": {
+        "internal": {
+            "org_id": "9999"
+        },
+        "type": "User",
+        "user": {
+            "email": "nonumber@example.com",
+            "first_name": "No",
+            "is_active": true,
+            "is_internal": true,
+            "is_org_admin": false,
+            "last_name": "Number",
+            "locale": "en_US",
+            "username": "nonumber"
+        }
+    }
+}
+"""
+
+AUTH_HEADER_NO_ACCT = {'X-RH-IDENTITY': 'eyJpZGVudGl0eSI6eyJ0eXBlIjoiVXNlciIsInVzZXIiO'
+                                        'nsidXNlcm5hbWUiOiJub251bWJlciIsImVtYWlsIjoibm'
+                                        '9udW1iZXJAZXhhbXBsZS5jb20iLCJmaXJzdF9uYW1lIjo'
+                                        'iTm8iLCJsYXN0X25hbWUiOiJOdW1iZXIiLCJpc19hY3Rp'
+                                        'dmUiOnRydWUsImlzX29yZ19hZG1pbiI6ZmFsc2UsImlzX'
+                                        '2ludGVybmFsIjp0cnVlLCJsb2NhbGUiOiJlbl9VUyJ9LC'
+                                        'JpbnRlcm5hbCI6eyJvcmdfaWQiOiI5OTk5In19fQo='}
 
 FETCH_SYSTEMS_RESULT = [
     {

--- a/tests/test_v0_api.py
+++ b/tests/test_v0_api.py
@@ -32,6 +32,13 @@ class ApiTests(unittest.TestCase):
                                    "system_ids[]=11b3cbce-25a9-11e9-8457-c85b761454fa")
         self.assertEqual(response.status_code, 400)
 
+    def test_compare_api_no_account_number(self):
+        response = self.client.get("r/insights/platform/drift/v0/compare?"
+                                   "system_ids[]=d6bba69a-25a8-11e9-81b8-c85b761454fa"
+                                   "system_ids[]=11b3cbce-25a9-11e9-8457-c85b761454fa",
+                                   headers=fixtures.AUTH_HEADER_NO_ACCT)
+        self.assertEqual(response.status_code, 400)
+
     @mock.patch('drift.views.v0.fetch_systems')
     def test_compare_api(self, mock_fetch_systems):
         mock_fetch_systems.return_value = fixtures.FETCH_SYSTEMS_RESULT
@@ -45,8 +52,8 @@ class ApiTests(unittest.TestCase):
     def test_compare_api_missing_system_uuid(self, mock_fetch_systems):
         mock_fetch_systems.side_effect = SystemNotReturned("oops")
         response = self.client.get("r/insights/platform/drift/v0/compare?"
-                                   "host_ids[]=d6bba69a-25a8-11e9-81b8-c85b761454fa"
-                                   "host_ids[]=11b3cbce-25a9-11e9-8457-c85b761454fa",
+                                   "system_ids[]=d6bba69a-25a8-11e9-81b8-c85b761454fa"
+                                   "system_ids[]=11b3cbce-25a9-11e9-8457-c85b761454fa",
                                    headers=fixtures.AUTH_HEADER)
         self.assertEqual(response.status_code, 400)
 


### PR DESCRIPTION
If a request comes in without the "account" field, reject it and
return a 400.

This also fixes a unit test that was testing the wrong error
condition. Test coverage should be :100: again.