### PR TITLE
use openapi to define API

### DIFF
--- a/drift/exceptions.py
+++ b/drift/exceptions.py
@@ -24,3 +24,13 @@ class SystemNotReturned(Exception):
         """
         super(SystemNotReturned, self).__init__()
         self.message = message
+
+
+class InventoryServiceError(Exception):
+    def __init__(self, message):
+        """
+        Raise this exception if the inventory service is not reachable or does
+        not provide a valid response
+        """
+        super(InventoryServiceError, self).__init__()
+        self.message = message

--- a/drift/info_parser.py
+++ b/drift/info_parser.py
@@ -4,12 +4,13 @@ DRIFT_SYSTEM_ID = {'id'}
 
 def build_comparisons(inventory_service_systems):
     """
-    given a list of system dicts, return a dict of comparisons, along with a dict of metadata.
+    given a list of system dicts, return a dict of comparisons, along with a
+    dict of system data
     """
     fact_comparison = _select_applicable_info(DRIFT_FACTS, inventory_service_systems)
 
-    metadata = [_system_metadata(system) for system in inventory_service_systems]
-    return {'facts': fact_comparison, 'metadata': metadata}
+    system_mappings = [_system_mapping(system) for system in inventory_service_systems]
+    return {'facts': fact_comparison, 'systems': system_mappings}
 
 
 def _select_applicable_info(info_keys, systems):
@@ -42,7 +43,7 @@ def _create_comparison(systems, info_name):
     """
     info_comparison = 'DIFFERENT'
 
-    system_values = {x['id']: x[info_name] for x in systems}
+    system_values = [{'id': x['id'], 'value': x[info_name]} for x in systems]
 
     # map the info values down to a set. This lets us check cardinality for sameness.
     if len({system[info_name] for system in systems}) == 1:
@@ -51,8 +52,8 @@ def _create_comparison(systems, info_name):
     return {'name': info_name, 'state': info_comparison, 'systems': system_values}
 
 
-def _system_metadata(system):
+def _system_mapping(system):
     """
-    create a metadata field for one system
+    create a header mapping for one system
     """
     return {'id': system['id'], 'fqdn': system['fqdn'], 'last_updated': system['updated']}

--- a/drift/openapi/api.spec.yaml
+++ b/drift/openapi/api.spec.yaml
@@ -11,20 +11,52 @@ info:
 servers:
   - url: /r/insights/platform/drift/v0
 
+
 paths:
   /status:
     get:
-      summary: health check call
+      summary: health check liveness call
       operationId: drift.views.v0.status
       tags:
         - status
       responses:
         '200':
-          description: a small JSON indicating the application is deployed
+          description: "A small JSON indicating the application is deployed.
+                        This serves as both the liveness and readiness call."
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Status"
+
+  /comparison_report:
+    parameters:
+      - $ref: '#/components/parameters/rhIdentityHeader'
+    get:
+      summary: fetch comparison report
+      description: "Fetch a comparison report for given system IDs. This will
+                    only fetch the most current system state using data from
+                    inventory service."
+      operationId: drift.views.v0.comparison_report
+      parameters:
+        - name: system_ids[]
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+          required: true
+          description: list of system IDs to generate report for
+      responses:
+        '200':
+          description: a comparison report for the given system IDs
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ComparisonReport"
+              examples:
+                jsonObject:
+                  summary: A sample comparison report
+                  externalValue: "https://git.io/fhQ00"
 
 components:
   schemas:
@@ -34,3 +66,70 @@ components:
       properties:
         status:
           type: string
+    ComparisonReport:
+      required:
+        - facts
+        - systems
+      properties:
+        facts:
+          type: array
+          items:
+            $ref: "#/components/schemas/FactComparison"
+        systems:
+          type: array
+          items:
+            $ref: "#/components/schemas/System"
+    FactComparison:
+      description: "A list of fact names, states, and systems. This is useful
+                    for displaying rows of facts to compare."
+      required:
+        - name
+        - state
+        - systems
+      properties:
+        name:
+          type: string
+        state:
+          type: string
+          enum: [SAME, DIFFERENT]
+        systems:
+          type: array
+          items:
+            $ref: "#/components/schemas/SystemIdValue"
+    SystemIdValue:
+      required:
+        - id
+        - value
+      properties:
+        id:
+          type: string
+          format: uuid
+        value:
+          type: string
+    System:
+      description: "The system ID, FQDN, and last updated timestamp for each
+                    system in the report"
+      required:
+        - fqdn
+        - id
+        - last_updated
+      properties:
+        fqdn:
+          type: string
+        id:
+          type: string
+          format: uuid
+        last_updated:
+          type: string
+          format: date-time
+  parameters:
+    rhIdentityHeader:
+      in: header
+      name: x-rh-identity
+      required: true
+      schema:
+        type: string
+      description: "Base64-encoded JSON identity header provided by 3Scale.
+                    Contains an account number of the user issuing the
+                    request. Format of the JSON:
+                    {'identity': {'account_number': '12345678'}}"

--- a/drift/views/v0.py
+++ b/drift/views/v0.py
@@ -14,25 +14,18 @@ API_VERSION_PREFIX = "/v0"
 section = Blueprint('v0', __name__, url_prefix=APP_URL_PREFIX + API_VERSION_PREFIX)
 
 
-@section.route("/comparison_report")
 def comparison_report():
     system_ids = request.args.getlist('system_ids[]')
     auth_key = get_key_from_headers(request.headers)
 
-    if not system_ids:
-        raise HTTPError(HTTPStatus.BAD_REQUEST, message='system_ids[] not specified')
-
-    if auth_key is None:
-        raise HTTPError(HTTPStatus.BAD_REQUEST, message="auth header not specified")
-
     try:
-        comparisons = info_parser.build_comparisons(fetch_systems(system_ids, auth_key))
+        comparisons = info_parser.build_comparisons(fetch_systems(system_ids, auth_key,
+                                                                  current_app.logger))
         return jsonify(comparisons)
     except SystemNotReturned as error:
         raise HTTPError(HTTPStatus.BAD_REQUEST, message=error.message)
 
 
-@section.route("/status")
 def status():
     return jsonify({'status': "running"})
 

--- a/tests/test_inventory_service_interface.py
+++ b/tests/test_inventory_service_interface.py
@@ -1,18 +1,32 @@
+import requests
 import responses
 import string
 import unittest
+import mock
 
-from drift import inventory_service_interface
-from drift.exceptions import SystemNotReturned
+from drift import app, inventory_service_interface
+from drift.exceptions import InventoryServiceError, SystemNotReturned
 from . import fixtures
 
 
 class InventoryServiceTests(unittest.TestCase):
 
+    def setUp(self):
+        test_connexion_app = app.create_app()
+        test_flask_app = test_connexion_app.app
+        self.client = test_flask_app.test_client()
+        self.mock_logger = mock.Mock()
+
     def _create_response_for_systems(self, service_hostname, system_uuids):
         url_template = "http://%s/r/insights/platform/inventory/api/v1/hosts/%s"
         responses.add(responses.GET, url_template % (service_hostname, system_uuids),
-                      body=fixtures.SYSTEMS_TEMPLATE, status=200,
+                      body=fixtures.SYSTEMS_TEMPLATE, status=requests.codes.ok,
+                      content_type='application/json')
+
+    def _create_500_response_for_systems(self, service_hostname, system_uuids):
+        url_template = "http://%s/r/insights/platform/inventory/api/v1/hosts/%s"
+        responses.add(responses.GET, url_template % (service_hostname, system_uuids),
+                      body="I am error", status=requests.codes.INTERNAL_SERVER_ERROR,
                       content_type='application/json')
 
     @responses.activate
@@ -23,7 +37,8 @@ class InventoryServiceTests(unittest.TestCase):
         self._create_response_for_systems('inventory_svc_url_is_not_set',
                                           ','.join(systems_to_fetch))
 
-        systems = inventory_service_interface.fetch_systems(systems_to_fetch, "my-auth-key")
+        systems = inventory_service_interface.fetch_systems(systems_to_fetch, "my-auth-key",
+                                                            self.mock_logger)
 
         found_system_ids = {system['id'] for system in systems}
         self.assertSetEqual(found_system_ids, set(systems_to_fetch))
@@ -38,16 +53,34 @@ class InventoryServiceTests(unittest.TestCase):
                                           ','.join(systems_to_fetch))
 
         with self.assertRaises(SystemNotReturned) as cm:
-            inventory_service_interface.fetch_systems(systems_to_fetch, "my-auth-key")
+            inventory_service_interface.fetch_systems(systems_to_fetch, "my-auth-key",
+                                                      self.mock_logger)
 
         self.assertEqual(cm.exception.message,
                          "System(s) 269a3da8-262f-11e9-8ee5-c85b761454fa not available to display")
+
+    @responses.activate
+    def test_fetch_systems_backend_service_error(self):
+        systems_to_fetch = ['243926fa-262f-11e9-a632-c85b761454fa',
+                            '264fb5b2-262f-11e9-9b12-c85b761454fa',
+                            '269a3da8-262f-11e9-8ee5-c85b761454fa']
+
+        self._create_500_response_for_systems('inventory_svc_url_is_not_set',
+                                              ','.join(systems_to_fetch))
+
+        with self.assertRaises(InventoryServiceError) as cm:
+            inventory_service_interface.fetch_systems(systems_to_fetch, "my-auth-key",
+                                                      self.mock_logger)
+
+        self.assertEqual(cm.exception.message,
+                         "Error received from backend service")
 
     def test_fetch_too_many_systems(self):
         systems_to_fetch = list(string.ascii_lowercase)
 
         with self.assertRaises(SystemNotReturned) as cm:
-            inventory_service_interface.fetch_systems(systems_to_fetch, "my-auth-key")
+            inventory_service_interface.fetch_systems(systems_to_fetch, "my-auth-key",
+                                                      self.mock_logger)
 
         self.assertEqual(cm.exception.message,
                          "Too many systems requested, limit is 20")


### PR DESCRIPTION
Previously, methods were mapped to URLs using flask annotations, and
data was validated inside the methods. This is not correct.

Instead, rely on openapi to define the method inputs. Additionally,
use the openapi definition to map URLs to methods.

This commit also handles 500 errors from the inventory service.

NOTE: the returned data from /comparison_report has changed slightly.
The old format for the list of facts was:

```
{UUID1: value1,
 UUID2: value2}
```

It is now:

```
{id: UUID1, value: value1}
{id: UUID2, value: value2}
```

The old style of having data inside of a hash key is not recommended
in the API specs I read.