### PR TITLE
Use system facts from 'facts' dict

### DIFF
--- a/drift/info_parser.py
+++ b/drift/info_parser.py
@@ -1,34 +1,53 @@
-DRIFT_FACTS = {'bios_uuid', 'display_name'}
-DRIFT_SYSTEM_ID = {'id'}
+SYSTEM_ID = 'id'
+FACT_NAMESPACE = 'inventory'
 
 
 def build_comparisons(inventory_service_systems):
     """
     given a list of system dicts, return a dict of comparisons, along with a dict of metadata.
     """
-    fact_comparison = _select_applicable_info(DRIFT_FACTS, inventory_service_systems)
+    fact_comparison = _select_applicable_info(inventory_service_systems)
 
     metadata = [_system_metadata(system) for system in inventory_service_systems]
     return {'facts': fact_comparison, 'metadata': metadata}
 
 
-def _select_applicable_info(info_keys, systems):
+def _select_applicable_info(systems):
     """
     Take a list of systems, and output a "pivoted" list of facts, where each fact
     key has a dict of systems and their values. This is useful when comparing
     facts across systems.
     """
-    # create dicts of system + info
-    ids_and_info = [{key: system[key] for key in (info_keys | DRIFT_SYSTEM_ID & system.keys())}
-                    for system in systems]
+    # create dicts of id + info
+    ids_and_info = [_system_facts_and_id(system) for system in systems]
 
     # TODO: we are assuming all info keys exist for each system. This is not a good assumption
     available_info_names = ids_and_info[0].keys()
 
     info_comparisons = [_create_comparison(ids_and_info, info_name)
                         for info_name in available_info_names
-                        if info_name in info_keys]
+                        if info_name is not SYSTEM_ID]
     return info_comparisons
+
+
+def _find_facts_for_namespace(system, namespace):
+    """
+    return the facts for the given namespace
+    """
+    for facts in system['facts']:
+        if facts['namespace'] == namespace:
+            return facts['facts']
+
+
+def _system_facts_and_id(system):
+    """
+    Pull the system facts dict out from a system record and add the ID to the dict
+    """
+    # TODO: we are assuming we just need to handle one namespace, and
+    # that the namespace is always present.
+    facts_and_id = _find_facts_for_namespace(system, FACT_NAMESPACE)
+    facts_and_id[SYSTEM_ID] = system[SYSTEM_ID]
+    return facts_and_id
 
 
 def _create_comparison(systems, info_name):

--- a/drift/inventory_service_interface.py
+++ b/drift/inventory_service_interface.py
@@ -31,4 +31,5 @@ def fetch_systems(system_ids, service_auth_key):
         system_ids_returned = {system['id'] for system in result['results']}
         missing_ids = set(system_ids) - system_ids_returned
         raise SystemNotReturned("System(s) %s not available to display" % ','.join(missing_ids))
+
     return result['results']

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -66,7 +66,12 @@ FETCH_SYSTEMS_RESULT = [
       "bios_uuid": "e380fd4a-28ae-11e9-974c-c85b761454fa",
       "created": "2019-01-31T13:00:00.100010Z",
       "display_name": None,
-      "facts": [],
+      "facts": [
+        {
+          "facts": {'fqdn': "fake_system_99.example.com"},
+          "namespace": "inventory"
+        }
+      ],
       "fqdn": "fake_system_99.example.com",
       "id": "fc1e497a-28ae-11e9-afd9-c85b761454fa",
       "insights_id": "01791a58-28af-11e9-9ab0-c85b761454fa",
@@ -99,7 +104,7 @@ SYSTEMS_TEMPLATE = '''
       "facts": [
         {
           "facts": {},
-          "namespace": "string"
+          "namespace": "inventory"
         }
       ],
       "fqdn": "system.example.com",
@@ -124,7 +129,7 @@ SYSTEMS_TEMPLATE = '''
       "facts": [
         {
           "facts": {},
-          "namespace": "string"
+          "namespace": "inventory"
         }
       ],
       "fqdn": "system2.example.com",


### PR DESCRIPTION
Previously, we massaged system data to pull a few facts based on
identification data like bios UUID and fqdn.

Instead, use the actual facts dictionary coming back from inventory
service.