### PR TITLE
Handle facts that are only on some systems

### DIFF
--- a/drift/constants.py
+++ b/drift/constants.py
@@ -1,0 +1,13 @@
+API_VERSION_PREFIX = "/v0"
+APP_URL_PREFIX = "/r/insights/platform/drift"
+AUTH_HEADER_NAME = 'X-RH-IDENTITY'
+FACT_NAMESPACE = "inventory"
+INVENTORY_SVC_HOSTS_ENDPOINT = '/r/insights/platform/inventory/api/v1/hosts/%s?per_page=%s'
+MAX_UUID_COUNT = 20
+MOCK_FACT_NAMESPACE = 'mockfacts'
+MOCK_FACTS_FILE = 'drift/mock_data/mockfacts.json'
+SYSTEM_ID_KEY = 'id'
+
+COMPARISON_SAME = "SAME"
+COMPARISON_DIFFERENT = "DIFFERENT"
+COMPARISON_INCOMPLETE_DATA = "INCOMPLETE_DATA"

--- a/drift/inventory_service_interface.py
+++ b/drift/inventory_service_interface.py
@@ -3,13 +3,9 @@ import requests
 from urllib.parse import urljoin
 
 from drift import config
+from drift.constants import AUTH_HEADER_NAME, INVENTORY_SVC_HOSTS_ENDPOINT, MAX_UUID_COUNT
 from drift.exceptions import SystemNotReturned, InventoryServiceError
 from drift.mock_data import mock_data
-
-AUTH_HEADER_NAME = 'X-RH-IDENTITY'
-INVENTORY_SVC_HOSTS_ENDPOINT = '/r/insights/platform/inventory/api/v1/hosts/%s?per_page=%s'
-
-MAX_UUID_COUNT = 20
 
 
 def get_key_from_headers(incoming_headers):
@@ -47,7 +43,7 @@ def fetch_systems(system_ids, service_auth_key, logger):
 
     if config.return_mock_data:
         for system in result['results']:
-            mock_facts = mock_data.fetch_mock_facts()
+            mock_facts = mock_data.fetch_mock_facts(system['id'])
             system['facts'].append(mock_facts)
 
     return result['results']

--- a/drift/mock_data/mock_data.py
+++ b/drift/mock_data/mock_data.py
@@ -1,17 +1,38 @@
 import json
 import uuid
+import random
+import hashlib
+import string
 
-MOCK_FACTS_FILE = 'drift/mock_data/mockfacts.json'
-MOCK_FACT_NAMESPACE = 'mockfacts'
+from drift.constants import MOCK_FACTS_FILE, MOCK_FACT_NAMESPACE
 
 
-def fetch_mock_facts():
+def fetch_mock_facts(seed):
     """
-    Load mock data from file as a dict, and add a randomly generated fact value
-    in "a.fresh.uuid"
+    Load mock data from file as a dict
     """
     with open(MOCK_FACTS_FILE) as f:
         factdata = f.read()
-    facts = json.loads(factdata)
-    facts['a.fresh.uuid'] = uuid.uuid4()
-    return {'facts': facts, 'namespace': MOCK_FACT_NAMESPACE}
+    static_facts = json.loads(factdata)
+    dynamic_facts = generate_additional_facts(seed)
+    return {'facts': {**static_facts, **dynamic_facts}, 'namespace': MOCK_FACT_NAMESPACE}
+
+
+def generate_additional_facts(seed):
+    """
+    Generate a few additional facts
+    """
+    m = hashlib.sha256()
+    seed_bytes = bytes(seed, 'utf-8')
+    m.update(seed_bytes)
+
+    facts = {}
+    facts['a.random.number'] = random.randint(1_000_000, 9_999_999)
+    facts['here.is.a.uuid'] = uuid.uuid4()
+    facts['seed.string'] = seed
+    facts['seed.hash'] = m.hexdigest()
+    facts['here.is.a.uuid'] = uuid.uuid4()
+
+    if seed[0] in string.ascii_lowercase:
+        facts['defined.for.seeds.that.start.with.a.letter'] = "True"
+    return facts

--- a/drift/views/v0.py
+++ b/drift/views/v0.py
@@ -5,14 +5,10 @@ import json
 import base64
 
 from drift import config, info_parser
+from drift.constants import APP_URL_PREFIX, API_VERSION_PREFIX, FACT_NAMESPACE, MOCK_FACT_NAMESPACE
 from drift.exceptions import HTTPError, SystemNotReturned
 from drift.inventory_service_interface import fetch_systems, get_key_from_headers
 
-APP_URL_PREFIX = "/r/insights/platform/drift"
-API_VERSION_PREFIX = "/v0"
-
-FACT_NAMESPACE = "inventory"
-MOCK_FACT_NAMESPACE = "mockfacts"
 
 section = Blueprint('v0', __name__, url_prefix=APP_URL_PREFIX + API_VERSION_PREFIX)
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -92,7 +92,105 @@ FETCH_SYSTEMS_RESULT = [
       "subscription_manager_id": "RHN Classic and Red Hat Subscription Management",
       "tags": [],
       "updated": "2019-01-31T14:00:00.500000Z"
-    }]
+    },
+    {
+      "account": "9876543",
+      "bios_uuid": "e380fd4a-28ae-11e9-974c-c85b761454fb",
+      "created": "2018-01-31T13:00:00.100010Z",
+      "display_name": None,
+      "facts": [
+        {
+          "facts": {'foo': "bar"},
+          "namespace": "inventory"
+        },
+        {
+          "facts": {'fakefact2': "qux"},
+          "namespace": "mockfacts"
+        }
+      ],
+      "fqdn": "fake_system_99.example.com",
+      "id": "bbbbbbbb-28ae-11e9-afd9-c85b761454fa",
+      "insights_id": "00000000-28af-11e9-9ab0-c85b761454fa",
+      "ip_addresses": [
+        "10.0.0.3",
+        "2620:52:0:2598:5054:ff:fecd:ae15"
+      ],
+      "mac_addresses": [
+        "52:54:00:cd:ae:00",
+        "00:00:00:00:00:00"
+      ],
+      "rhel_machine_id": None,
+      "satellite_id": None,
+      "subscription_manager_id": "RHN Classic and Red Hat Subscription Management",
+      "tags": [],
+      "updated": "2018-01-31T14:00:00.500000Z"}
+    ]
+
+FETCH_SYSTEMS_SAME_FACTS_RESULT = [
+    {
+      "account": "9876543",
+      "bios_uuid": "e380fd4a-28ae-11e9-974c-c85b761454fa",
+      "created": "2019-01-31T13:00:00.100010Z",
+      "display_name": None,
+      "facts": [
+        {
+          "facts": {'fqdn': "fake_system_99.example.com"},
+          "namespace": "inventory"
+        },
+        {
+          "facts": {'fakefact': "pretend_this_fact_was_injected_via_RETURN_MOCK_DATA"},
+          "namespace": "mockfacts"
+        }
+      ],
+      "fqdn": "fake_system_99.example.com",
+      "id": "fc1e497a-28ae-11e9-afd9-c85b761454fa",
+      "insights_id": "01791a58-28af-11e9-9ab0-c85b761454fa",
+      "ip_addresses": [
+        "10.0.0.3",
+        "2620:52:0:2598:5054:ff:fecd:ae15"
+      ],
+      "mac_addresses": [
+        "52:54:00:cd:ae:00",
+        "00:00:00:00:00:00"
+      ],
+      "rhel_machine_id": None,
+      "satellite_id": None,
+      "subscription_manager_id": "RHN Classic and Red Hat Subscription Management",
+      "tags": [],
+      "updated": "2019-01-31T14:00:00.500000Z"
+    },
+    {
+      "account": "9876543",
+      "bios_uuid": "e380fd4a-28ae-11e9-974c-c85b761454fb",
+      "created": "2018-01-31T13:00:00.100010Z",
+      "display_name": None,
+      "facts": [
+        {
+          "facts": {'fqdn': "fake_system_99.example.com"},
+          "namespace": "inventory"
+        },
+        {
+          "facts": {'fakefact': "pretend_this_fact_was_injected_via_RETURN_MOCK_DATA"},
+          "namespace": "mockfacts"
+        }
+      ],
+      "fqdn": "fake_system_99.example.com",
+      "id": "bbbbbbbb-28ae-11e9-afd9-c85b761454fa",
+      "insights_id": "00000000-28af-11e9-9ab0-c85b761454fa",
+      "ip_addresses": [
+        "10.0.0.3",
+        "2620:52:0:2598:5054:ff:fecd:ae15"
+      ],
+      "mac_addresses": [
+        "52:54:00:cd:ae:00",
+        "00:00:00:00:00:00"
+      ],
+      "rhel_machine_id": None,
+      "satellite_id": None,
+      "subscription_manager_id": "RHN Classic and Red Hat Subscription Management",
+      "tags": [],
+      "updated": "2018-01-31T14:00:00.500000Z"}
+    ]
 
 SYSTEMS_TEMPLATE = '''
     {
@@ -107,7 +205,7 @@ SYSTEMS_TEMPLATE = '''
       "display_name": "system1.example.com",
       "facts": [
         {
-          "facts": {},
+          "facts": {"foo": "bar"},
           "namespace": "inventory"
         }
       ],

--- a/tests/test_v0_api.py
+++ b/tests/test_v0_api.py
@@ -49,6 +49,15 @@ class ApiTests(unittest.TestCase):
                                    headers=fixtures.AUTH_HEADER)
         self.assertEqual(response.status_code, 200)
 
+    @mock.patch('drift.views.v0.fetch_systems')
+    def test_comparison_report_api_same_facts(self, mock_fetch_systems):
+        mock_fetch_systems.return_value = fixtures.FETCH_SYSTEMS_SAME_FACTS_RESULT
+        response = self.client.get("r/insights/platform/drift/v0/comparison_report?"
+                                   "system_ids[]=d6bba69a-25a8-11e9-81b8-c85b761454fa"
+                                   "system_ids[]=11b3cbce-25a9-11e9-8457-c85b761454fa",
+                                   headers=fixtures.AUTH_HEADER)
+        self.assertEqual(response.status_code, 200)
+
     @mock.patch('drift.views.v0.config')
     @mock.patch('drift.views.v0.fetch_systems')
     def test_comparison_report_api_mock_facts(self, mock_fetch_systems, mock_config):


### PR DESCRIPTION
Previously, we assumed that all systems have the same set of facts. However,
it's very likely that systems have different sets of facts defined.

This commit adds additional mock facts, and adds a new fact that only appears
if the system UUID starts with a lowercase letter.

Additionally, the comparison now allows for facts that are not defined on all
systems. If a fact is only defined on some systems, the comparison will say
"INCOMPLETE_DATA" as the value for systems where the fact is missing.

Note that if a system really does have a system fact with the value of
"INCOMPLETE_DATA", the comparison report may show the incorrect state. I don't
think there is a way around this, since any value we choose needs to be
serialized to a string for the JSON object.

This commit also creates a `constants.py` which contains all constants. There
were a couple of strings that I did not move into constants (for example,
`"facts"`). It was a bit of a judgment call on which should move and which
shouldn't.