### PR TITLE
Prefix mock facts with "MOCK-"

### DIFF
--- a/drift/mock_data/mock_data.py
+++ b/drift/mock_data/mock_data.py
@@ -15,7 +15,9 @@ def fetch_mock_facts(seed):
         factdata = f.read()
     static_facts = json.loads(factdata)
     dynamic_facts = generate_additional_facts(seed)
-    return {'facts': {**static_facts, **dynamic_facts}, 'namespace': MOCK_FACT_NAMESPACE}
+    facts = {**static_facts, **dynamic_facts}
+    prefixed_facts = {"MOCK-" + fact_key: facts[fact_key] for fact_key in facts.keys()}
+    return {'facts': prefixed_facts, 'namespace': MOCK_FACT_NAMESPACE}
 
 
 def generate_additional_facts(seed):


### PR DESCRIPTION
It was difficult to tell if a user was receiving mock facts or real facts. We
now prefix each mock fact with "MOCK-" to make it more obvious.