### PR TITLE
Document error responses in openapi

### DIFF
--- a/drift/openapi/api.spec.yaml
+++ b/drift/openapi/api.spec.yaml
@@ -57,9 +57,41 @@ paths:
                 jsonObject:
                   summary: A sample comparison report
                   externalValue: "https://git.io/fhQ00"
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
 components:
+  responses:
+    InternalServerError:
+      description: "An internal server error has occurred."
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    BadRequest:
+      description: "The server could could not process the current request."
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
   schemas:
+    Error:
+      required:
+        - detail
+        - status
+        - title
+        - type
+      properties:
+        detail:
+          type: string
+        status:
+          type: integer
+        title:
+          type: string
+        type:
+          type: string
     Status:
       required:
         - status


### PR DESCRIPTION
Previously, only the 200 was documented. Now the 200, 400 and 500 (all of the
codes we return via app code) are documented.

I thought there was a standard error response but it looks like each app does
its own thing. As long as ours is documented, we are in good shape.