### PR TITLE
disable CORS

### DIFF
--- a/drift/app.py
+++ b/drift/app.py
@@ -1,5 +1,4 @@
 import connexion
-from flask_cors import CORS
 
 from drift import config
 from drift.views import v0
@@ -16,7 +15,6 @@ def create_app():
     connexion_app = connexion.App(__name__, specification_dir='openapi/')
     connexion_app.add_api('api.spec.yaml')
     flask_app = connexion_app.app
-    CORS(flask_app)
     flask_app.register_blueprint(v0.section)
     flask_app.register_error_handler(HTTPError, handle_http_error)
     flask_app.logger.setLevel(config.log_level)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 Flask>=0.9
 connexion
 connexion[swagger-ui]
-flask-cors


### PR DESCRIPTION
Previously, we had CORS enabled as part of the week 1 sprint. I don't remember
exactly, but I think we did this before we had insights-proxy and the CI
environment wired up.

This appears to not be needed anymore since all requests go through the same
hostname, so its OK to disable again.