### PR TITLE
enable APP_NAME and PATH_PREFIX env vars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ python:
 
 script:
   - flake8
-  - yamllint drift/openapi/mgmt_api.spec.yaml
-  - yamllint drift/openapi/api.spec.yaml
   - ./run_unit_tests.sh
 
 install:

--- a/README.md
+++ b/README.md
@@ -23,12 +23,14 @@ one.
 
 The same info as above, but in handy table form:
 
-| env var name              | required? | expected values | description                                     |
-| ------------              | --------- | --------------- | ------------                                    |
-| INVENTORY_SVC_URL         | yes       | URL             | URL for inventory service (do not include path) |
-| LOG_LEVEL                 | no        | string          | lowercase log level (info by default)           |
-| RETURN_MOCK_DATA          | no        | boolean         | return fake facts                               |
-| prometheus_multiproc_dir  | yes       | string          | path to dir for sharing stats between processes |
+| env var name              | required? | expected values | description                                       |
+| ------------              | --------- | --------------- | ------------                                      |
+| INVENTORY_SVC_URL         | yes       | URL             | URL for inventory service (do not include path)   |
+| LOG_LEVEL                 | no        | string          | lowercase log level (info by default)             |
+| RETURN_MOCK_DATA          | no        | boolean         | return fake facts                                 |
+| prometheus_multiproc_dir  | yes       | string          | path to dir for sharing stats between processes   |
+| PATH_PREFIX               | no        | string          | API path prefix (default: `/r/insights/platform`) |
+| APP_NAME                  | no        | string          | API app name (default: `drift`)                   |
 
 If you would like to use this service with insights-proxy, you can use the
 included `local-drift-backend.js` like so:

--- a/drift/app.py
+++ b/drift/app.py
@@ -1,6 +1,7 @@
 import connexion
 import logging
 
+from drift import config
 from drift.views import v0
 from drift.error import handle_http_error
 from drift.exceptions import HTTPError
@@ -13,7 +14,8 @@ def create_app():
     :return:    flask app
     :rtype:     Flask
     """
-    connexion_app = connexion.App(__name__, specification_dir='openapi/')
+    openapi_args = {'path_prefix': config.path_prefix, 'app_name': config.app_name}
+    connexion_app = connexion.App(__name__, specification_dir='openapi/', arguments=openapi_args)
     connexion_app.add_api('api.spec.yaml')
     connexion_app.add_api('mgmt_api.spec.yaml')
     flask_app = connexion_app.app

--- a/drift/config.py
+++ b/drift/config.py
@@ -5,3 +5,6 @@ log_level = os.getenv('LOG_LEVEL', "INFO")
 inventory_svc_hostname = os.getenv('INVENTORY_SVC_URL', "http://inventory_svc_url_is_not_set")
 return_mock_data = os.getenv('RETURN_MOCK_DATA', False)
 prometheus_multiproc_dir = os.getenv('prometheus_multiproc_dir', None)
+
+path_prefix = os.getenv('PATH_PREFIX', '/r/insights/platform/')
+app_name = os.getenv('APP_NAME', 'drift')

--- a/drift/constants.py
+++ b/drift/constants.py
@@ -1,5 +1,4 @@
 API_VERSION_PREFIX = "/v0"
-APP_URL_PREFIX = "/r/insights/platform/drift"
 AUTH_HEADER_NAME = 'X-RH-IDENTITY'
 FACT_NAMESPACE = "inventory"
 INVENTORY_SVC_HOSTS_ENDPOINT = '/r/insights/platform/inventory/api/v1/hosts/%s?per_page=%s'

--- a/drift/openapi/api.spec.yaml
+++ b/drift/openapi/api.spec.yaml
@@ -9,8 +9,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
 
 servers:
-  - url: /r/insights/platform/drift/v0
-
+  - url: {{ path_prefix }}{{ app_name }}/v0
 
 paths:
   /comparison_report:

--- a/drift/views/v0.py
+++ b/drift/views/v0.py
@@ -4,14 +4,13 @@ import logging
 import json
 import base64
 
-
 from drift import config, info_parser, metrics
-from drift.constants import APP_URL_PREFIX, API_VERSION_PREFIX, FACT_NAMESPACE, MOCK_FACT_NAMESPACE
+from drift.constants import FACT_NAMESPACE, MOCK_FACT_NAMESPACE
 from drift.exceptions import HTTPError, SystemNotReturned
 from drift.inventory_service_interface import fetch_systems, get_key_from_headers
 
 
-section = Blueprint('v0', __name__, url_prefix=APP_URL_PREFIX + API_VERSION_PREFIX)
+section = Blueprint('v0', __name__)
 
 
 @metrics.comparison_report_requests.time()

--- a/openshift/templates/drift-backend.dc.yaml
+++ b/openshift/templates/drift-backend.dc.yaml
@@ -30,6 +30,10 @@ spec:
         - env:
             - name: APP_CONFIG
               value: gunicorn.conf.py
+            - name: PATH_PREFIX
+              value: /r/insights/platform/
+            - name: APP_NAME
+              value: drift
           image: {{ project }}/drift-backend:latest
           imagePullPolicy: Always
           name: drift-backend


### PR DESCRIPTION
Insights recommends that apps allow configuration of the API path via env var.

This commit allows setting these via env var, but defaults to the usual values
(see readme).