### PR TITLE
use real facts from the inventory service

### DIFF
--- a/drift/constants.py
+++ b/drift/constants.py
@@ -1,6 +1,6 @@
 API_VERSION_PREFIX = "/v0"
 AUTH_HEADER_NAME = 'X-RH-IDENTITY'
-FACT_NAMESPACE = "inventory"
+FACT_NAMESPACE = "system_profile"
 INVENTORY_SVC_HOSTS_ENDPOINT = '/r/insights/platform/inventory/api/v1/hosts/%s?per_page=%s'
 MAX_UUID_COUNT = 20
 MOCK_FACT_NAMESPACE = 'mockfacts'

--- a/drift/info_parser.py
+++ b/drift/info_parser.py
@@ -35,16 +35,27 @@ def _select_applicable_info(systems, fact_namespace):
     return info_comparisons
 
 
+def _flatten_list_facts(facts):
+    # TODO: this should likely be handled in PUP
+    for fact in facts:
+        if fact in ['os.kernel_modules', 'system_properties.hostnames']:
+            facts[fact] = ', '.join(facts[fact])
+
+    return facts
+
+
 def _find_facts_for_namespace(system, fact_namespace):
     """
     return the facts for the given namespace
     """
-    # TODO: we are assuming we just need to handle one namespace, and
-    # that the namespace is always present.
+    # TODO: we are assuming we just need to handle one namespace
     for facts in system['facts']:
         if facts['namespace'] == fact_namespace:
-            dataframe = json_normalize(facts['facts'], sep='.')
+            dataframe = json_normalize(_flatten_list_facts(facts['facts']), sep='.')
+            # TODO: we should transform this in PUP, not here
+            dataframe = dataframe.replace({True: "enabled", False: "disabled"})
             return dataframe.to_dict(orient='records')[0]
+    return {}
 
 
 def _system_facts_and_id(system, fact_namespace):


### PR DESCRIPTION
This commit reads facts off of the "system_profile" fact namespace, so mock
facts do not need to be used anymore.

This commit adds a couple of TODO items in the code. I wanted to get this
commit in so we can get a full end to end of checkin to display, and we can
start treating issues as bugs. I will add cards for the new TODO items.