### PR TITLE
flatten kernel module list

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -68,11 +68,15 @@ FETCH_SYSTEMS_RESULT = [
       "display_name": None,
       "facts": [
         {
-          "facts": {'fqdn': "fake_system_99.example.com"},
+          "facts": {'fqdn': "fake_system_99.example.com",
+                    'os.kernel_modules': ["fat16", "com4"],
+                    'system_properties.hostnames': ["fake", "fake2"]},
           "namespace": "inventory"
         },
         {
-          "facts": {'fakefact': "pretend_this_fact_was_injected_via_RETURN_MOCK_DATA"},
+          "facts": {'fqdn': "fake_system_99.example.com",
+                    'os.kernel_modules': ["fat16", "com4"],
+                    'system_properties.hostnames': ["fake", "fake2"]},
           "namespace": "mockfacts"
         }
       ],


### PR DESCRIPTION
The kernel module list was previously presented as a large string. This commit
breaks it apart into smaller facts that can be compared by the frontend app.

This commit also sorts all of the facts by key, which makes the web UI easier
to read.