### PR TITLE
set fact as "PARSE_ERROR" if we cannot parse it

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -21,3 +21,7 @@ openapi-spec-validator = "==0.2.4"
 
 [requires]
 python_version = "3.7"
+
+[scripts]
+flask = "python standalone_flask_server.py"
+tests = "bash run_unit_tests.sh"

--- a/drift/info_parser.py
+++ b/drift/info_parser.py
@@ -41,16 +41,19 @@ def _flatten_list_facts(facts):
     # TODO: this should likely be handled in PUP
     appended_facts = {}
     for fact in facts:
-        # fact lists that we want to flatten w/ fact-specific verb
-        if fact in ['os.kernel_modules']:
-            for kernel_module in facts['os.kernel_modules']:
-                appended_facts['os.kernel_modules.' + kernel_module] = "loaded"
-        if fact in ['cpu_flags']:
-            for cpu_flag in facts['cpu_flags']:
-                appended_facts['cpu_flags.' + cpu_flag] = "enabled"
-        # if we don't know what to do with the list, just join it
-        elif type(facts[fact]) is list:
-            facts[fact] = ', '.join(sorted(facts[fact]))
+        try:
+            # fact lists that we want to flatten w/ fact-specific verb
+            if fact in ['os.kernel_modules']:
+                for kernel_module in facts['os.kernel_modules']:
+                    appended_facts['os.kernel_modules.' + kernel_module] = "loaded"
+            if fact in ['cpu_flags']:
+                for cpu_flag in facts['cpu_flags']:
+                    appended_facts['cpu_flags.' + cpu_flag] = "enabled"
+            # if we don't know what to do with the list, just join it
+            elif type(facts[fact]) is list:
+                facts[fact] = ', '.join(sorted(facts[fact]))
+        except TypeError:
+            facts[fact] = "PARSE_ERROR"
 
     facts.update(appended_facts)
     # remove facts that we have already flattened


### PR DESCRIPTION
Previously, we would raise a 500 error if a fact was unparseable.
Instead, just mark the fact as having a value of PARSE_ERROR and
continue. This way, users still get most of the facts and have enough
info to raise a bug.