### PR TITLE
Require Python 3.6

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -20,7 +20,7 @@ pandas = "*"
 openapi-spec-validator = "==0.2.4"
 
 [requires]
-python_version = "3.7"
+python_version = "3.6"
 
 [scripts]
 flask = "python standalone_flask_server.py"


### PR DESCRIPTION
Previously, we required Python 3.7. Some systems do not have 3.7
available, and we do not use any 3.7-specific features.

This commit bumps the requirement down to Python 3.6.