### PR TITLE
Support package profiles

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -83,6 +83,8 @@ FETCH_SYSTEMS_RESULT = [
                                            "name": "eth0",
                                            "state": "UP",
                                            "type": "ether"},
+                    'installed_packages': ["httpd-filesystem-2.4.37-5.fc29.noarch",
+                                           "python3-langtable-0.0.39-1.fc29.noarch"],
                     'system_properties.hostnames': ["fake", "fake2"]},
           "namespace": "mockfacts"
         }


### PR DESCRIPTION
This commit reads the 'installed_packages' fact and splits it out into
one fact per package. The package name is in the fact name, and the VRA
is the value. For right now, the epoch is unused.

Note that this will change when inventory service is updated to support
installed packages.