### PR TITLE
use better default for PATH_PREFIX

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The same info as above, but in handy table form:
 | LOG_LEVEL                 | no        | string          | lowercase log level (info by default)             |
 | RETURN_MOCK_DATA          | no        | boolean         | return fake facts                                 |
 | prometheus_multiproc_dir  | yes       | string          | path to dir for sharing stats between processes   |
-| PATH_PREFIX               | no        | string          | API path prefix (default: `/r/insights/platform`) |
+| PATH_PREFIX               | no        | string          | API path prefix (default: `/api`)                 |
 | APP_NAME                  | no        | string          | API app name (default: `drift`)                   |
 
 If you would like to use this service with insights-proxy, you can use the

--- a/drift/config.py
+++ b/drift/config.py
@@ -6,5 +6,5 @@ inventory_svc_hostname = os.getenv('INVENTORY_SVC_URL', "http://inventory_svc_ur
 return_mock_data = os.getenv('RETURN_MOCK_DATA', False)
 prometheus_multiproc_dir = os.getenv('prometheus_multiproc_dir', None)
 
-path_prefix = os.getenv('PATH_PREFIX', '/r/insights/platform/')
+path_prefix = os.getenv('PATH_PREFIX', '/api/')
 app_name = os.getenv('APP_NAME', 'drift')


### PR DESCRIPTION
The `PATH_PREFIX` variable had an incorrect default value of the old
API path. Instead, use the new path.