### PR TITLE
fix unit tests

### DIFF
--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -5,6 +5,4 @@
 
 TEMPDIR=`mktemp -d`
 
-prometheus_multiproc_dir=$TEMPDIR nosetests --with-coverage --cover-package drift  --cover-min-percentage 95 --cover-erase
-
-rm -rf $TEMPDIR
+prometheus_multiproc_dir=$TEMPDIR nosetests --with-coverage --cover-package drift  --cover-min-percentage 95 --cover-erase && rm -rf $TEMPDIR

--- a/tests/test_v0_api.py
+++ b/tests/test_v0_api.py
@@ -17,24 +17,24 @@ class ApiTests(unittest.TestCase):
         self.client = test_flask_app.test_client()
 
     def test_comparison_report_api_no_args_or_header(self):
-        response = self.client.get("r/insights/platform/drift/v0/comparison_report")
+        response = self.client.get("api/drift/v0/comparison_report")
         self.assertEqual(response.status_code, 400)
 
     def test_comparison_report_api_no_header(self):
-        response = self.client.get("r/insights/platform/drift/v0/comparison_report?"
+        response = self.client.get("api/drift/v0/comparison_report?"
                                    "system_ids[]=d6bba69a-25a8-11e9-81b8-c85b761454fa"
                                    "system_ids[]=11b3cbce-25a9-11e9-8457-c85b761454fa")
         self.assertEqual(response.status_code, 400)
 
     def test_compare_api_no_account_number(self):
-        response = self.client.get("r/insights/platform/drift/v0/compare?"
+        response = self.client.get("api/drift/v0/compare?"
                                    "system_ids[]=d6bba69a-25a8-11e9-81b8-c85b761454fa"
                                    "&system_ids[]=11b3cbce-25a9-11e9-8457-c85b761454fa",
                                    headers=fixtures.AUTH_HEADER_NO_ACCT)
         self.assertEqual(response.status_code, 400)
 
     def test_comparison_report_duplicate_uuid(self):
-        response = self.client.get("r/insights/platform/drift/v0/comparison_report?"
+        response = self.client.get("api/drift/v0/comparison_report?"
                                    "system_ids[]=d6bba69a-25a8-11e9-81b8-c85b761454fa"
                                    "&system_ids[]=d6bba69a-25a8-11e9-81b8-c85b761454fa",
                                    headers=fixtures.AUTH_HEADER)
@@ -43,7 +43,7 @@ class ApiTests(unittest.TestCase):
     @mock.patch('drift.views.v0.fetch_systems')
     def test_comparison_report_api(self, mock_fetch_systems):
         mock_fetch_systems.return_value = fixtures.FETCH_SYSTEMS_RESULT
-        response = self.client.get("r/insights/platform/drift/v0/comparison_report?"
+        response = self.client.get("api/drift/v0/comparison_report?"
                                    "system_ids[]=d6bba69a-25a8-11e9-81b8-c85b761454fa"
                                    "&system_ids[]=11b3cbce-25a9-11e9-8457-c85b761454fa",
                                    headers=fixtures.AUTH_HEADER)
@@ -52,7 +52,7 @@ class ApiTests(unittest.TestCase):
     @mock.patch('drift.views.v0.fetch_systems')
     def test_comparison_report_api_same_facts(self, mock_fetch_systems):
         mock_fetch_systems.return_value = fixtures.FETCH_SYSTEMS_SAME_FACTS_RESULT
-        response = self.client.get("r/insights/platform/drift/v0/comparison_report?"
+        response = self.client.get("api/drift/v0/comparison_report?"
                                    "system_ids[]=d6bba69a-25a8-11e9-81b8-c85b761454fa"
                                    "&system_ids[]=11b3cbce-25a9-11e9-8457-c85b761454fa",
                                    headers=fixtures.AUTH_HEADER)
@@ -65,7 +65,7 @@ class ApiTests(unittest.TestCase):
         mock_config.return_mock_data = True
         mock_fetch_systems.return_value = fixtures.FETCH_SYSTEMS_RESULT
 
-        response = self.client.get("r/insights/platform/drift/v0/comparison_report?"
+        response = self.client.get("api/drift/v0/comparison_report?"
                                    "system_ids[]=d6bba69a-25a8-11e9-81b8-c85b761454fa"
                                    "&system_ids[]=11b3cbce-25a9-11e9-8457-c85b761454fa",
                                    headers=fixtures.AUTH_HEADER)
@@ -74,7 +74,7 @@ class ApiTests(unittest.TestCase):
     @mock.patch('drift.views.v0.fetch_systems')
     def test_comparison_report_api_missing_system_uuid(self, mock_fetch_systems):
         mock_fetch_systems.side_effect = SystemNotReturned("oops")
-        response = self.client.get("r/insights/platform/drift/v0/comparison_report?"
+        response = self.client.get("api/drift/v0/comparison_report?"
                                    "system_ids[]=d6bba69a-25a8-11e9-81b8-c85b761454fa"
                                    "&system_ids[]=11b3cbce-25a9-11e9-8457-c85b761454fa",
                                    headers=fixtures.AUTH_HEADER)
@@ -83,7 +83,7 @@ class ApiTests(unittest.TestCase):
     @mock.patch('drift.views.v0.fetch_systems')
     def test_comparison_report_api_500_backend(self, mock_fetch_systems):
         mock_fetch_systems.side_effect = InventoryServiceError("oops")
-        response = self.client.get("r/insights/platform/drift/v0/comparison_report?"
+        response = self.client.get("api/drift/v0/comparison_report?"
                                    "system_ids[]=d6bba69a-25a8-11e9-81b8-c85b761454fa"
                                    "&system_ids[]=11b3cbce-25a9-11e9-8457-c85b761454fa",
                                    headers=fixtures.AUTH_HEADER)
@@ -105,7 +105,7 @@ class DebugLoggingApiTests(unittest.TestCase):
     @mock.patch('drift.views.v0.get_key_from_headers')
     def test_username_logging_on_debug_no_key(self, mock_get_key):
         mock_get_key.return_value = None
-        self.client.get("r/insights/platform/drift/v0/status")
+        self.client.get("api/drift/v0/status")
         self.handler.flush()
         self.assertIn("identity header not sent for request", self.stream.getvalue())
         self.assertNotIn("username from identity header", self.stream.getvalue())
@@ -113,7 +113,7 @@ class DebugLoggingApiTests(unittest.TestCase):
     @mock.patch('drift.views.v0.get_key_from_headers')
     def test_username_logging_on_debug_with_key(self, mock_get_key):
         mock_get_key.return_value = fixtures.AUTH_HEADER['X-RH-IDENTITY']
-        self.client.get("r/insights/platform/drift/v0/status")
+        self.client.get("api/drift/v0/status")
         self.handler.flush()
         self.assertNotIn("identity header not sent for request", self.stream.getvalue())
         self.assertIn("username from identity header: test_user", self.stream.getvalue())


### PR DESCRIPTION
The unit test run script ended with `rm`, which almost always returns
zero. This meant that travis thought tests were passing when they
failed.

This commit fixed the test script, and also fixes the broken test.