### PR TITLE
rename v0 to v1 api

### DIFF
--- a/drift/app.py
+++ b/drift/app.py
@@ -2,7 +2,7 @@ import connexion
 import logging
 
 from drift import config
-from drift.views import v0
+from drift.views import v1
 from drift.error import handle_http_error
 from drift.exceptions import HTTPError
 from drift.metrics_registry import create_prometheus_registry_dir
@@ -27,6 +27,6 @@ def create_app():
     flask_app.logger.handlers = gunicorn_logger.handlers
     flask_app.logger.setLevel(gunicorn_logger.level)
 
-    flask_app.register_blueprint(v0.section)
+    flask_app.register_blueprint(v1.section)
     flask_app.register_error_handler(HTTPError, handle_http_error)
     return connexion_app

--- a/drift/constants.py
+++ b/drift/constants.py
@@ -1,4 +1,3 @@
-API_VERSION_PREFIX = "/v0"
 AUTH_HEADER_NAME = 'X-RH-IDENTITY'
 FACT_NAMESPACE = "system_profile"
 INVENTORY_SVC_SYSTEMS_ENDPOINT = '/api/inventory/v1/hosts/%s?per_page=%s'

--- a/drift/info_parser.py
+++ b/drift/info_parser.py
@@ -219,4 +219,12 @@ def _system_mapping(system):
     """
     create a header mapping for one system
     """
-    return {'id': system[SYSTEM_ID_KEY], 'fqdn': system['fqdn'], 'last_updated': system['updated']}
+    # this mimics how the inventory service modal displays names.
+    name = system['id']
+    if system.get('fqdn'):
+        name = system.get('fqdn')
+    if system.get('display_name'):
+        name = system.get('display_name')
+
+    return {'id': system[SYSTEM_ID_KEY], 'display_name': name,
+            'last_updated': system.get('updated', None)}

--- a/drift/openapi/api.spec.yaml
+++ b/drift/openapi/api.spec.yaml
@@ -1,7 +1,7 @@
 ---
 openapi: 3.0.1
 info:
-  version: "0.1"
+  version: "1.0"
   title: Drift Backend Service
   description: Service that returns differences between systems.
   license:
@@ -9,7 +9,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
 
 servers:
-  - url: "{{ path_prefix }}{{ app_name }}/v0"
+  - url: "{{ path_prefix }}{{ app_name }}/v1"
 
 paths:
   /comparison_report:
@@ -20,7 +20,7 @@ paths:
       description: "Fetch a comparison report for given system IDs. This will
                     only fetch the most current system state using data from
                     inventory service."
-      operationId: drift.views.v0.comparison_report
+      operationId: drift.views.v1.comparison_report
       parameters:
         - name: system_ids[]
           in: query
@@ -125,14 +125,16 @@ components:
         value:
           type: string
     System:
-      description: "The system ID, FQDN, and last updated timestamp for each
-                    system in the report"
+      description: "The system ID, display_name, and last updated timestamp for each
+                    system in the report. The display_name will try to populate
+                    from the inventory service record's display_name, fqdn, and
+                    finally ID."
       required:
-        - fqdn
+        - display_name
         - id
         - last_updated
       properties:
-        fqdn:
+        display_name:
           type: string
         id:
           type: string

--- a/drift/views/v1.py
+++ b/drift/views/v1.py
@@ -9,7 +9,7 @@ from drift.exceptions import HTTPError, SystemNotReturned
 from drift.inventory_service_interface import fetch_systems_with_profiles, get_key_from_headers
 
 
-section = Blueprint('v0', __name__)
+section = Blueprint('v1', __name__)
 
 
 @metrics.comparison_report_requests.time()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -95,8 +95,31 @@ FETCH_SYSTEMS_WITH_PROFILES_RESULT = [
       "account": "9876543",
       "bios_uuid": "e380fd4a-28ae-11e9-974c-c85b761454fb",
       "created": "2018-01-31T13:00:00.100010Z",
-      "display_name": None,
+      "display_name": "hello",
       "fqdn": "fake_system_99.example.com",
+      "id": "bbbbbbbb-28ae-11e9-afd9-c85b761454fa",
+      "insights_id": "00000000-28af-11e9-9ab0-c85b761454fa",
+      "ip_addresses": [
+        "10.0.0.3",
+        "2620:52:0:2598:5054:ff:fecd:ae15"
+      ],
+      "mac_addresses": [
+        "52:54:00:cd:ae:00",
+        "00:00:00:00:00:00"
+      ],
+      "rhel_machine_id": None,
+      "satellite_id": None,
+      "subscription_manager_id": "RHN Classic and Red Hat Subscription Management",
+      "system_profile": {'salutation': "hi",
+                         "id": "bbbbbbbb-28ae-11e9-afd9-c85b761454fa"},
+      "tags": [],
+      "updated": "2018-01-31T14:00:00.500000Z"},
+    {
+      "account": "9876543",
+      "bios_uuid": "e380fd4a-28ae-11e9-974c-c85b761454fb",
+      "created": "2018-01-31T13:00:00.100010Z",
+      "display_name": None,
+      "fqdn": None,
       "id": "bbbbbbbb-28ae-11e9-afd9-c85b761454fa",
       "insights_id": "00000000-28af-11e9-9ab0-c85b761454fa",
       "ip_addresses": [

--- a/tests/test_v1_api.py
+++ b/tests/test_v1_api.py
@@ -17,60 +17,60 @@ class ApiTests(unittest.TestCase):
         self.client = test_flask_app.test_client()
 
     def test_comparison_report_api_no_args_or_header(self):
-        response = self.client.get("api/drift/v0/comparison_report")
+        response = self.client.get("api/drift/v1/comparison_report")
         self.assertEqual(response.status_code, 400)
 
     def test_comparison_report_api_no_header(self):
-        response = self.client.get("api/drift/v0/comparison_report?"
+        response = self.client.get("api/drift/v1/comparison_report?"
                                    "system_ids[]=d6bba69a-25a8-11e9-81b8-c85b761454fa"
                                    "system_ids[]=11b3cbce-25a9-11e9-8457-c85b761454fa")
         self.assertEqual(response.status_code, 400)
 
     def test_compare_api_no_account_number(self):
-        response = self.client.get("api/drift/v0/compare?"
+        response = self.client.get("api/drift/v1/compare?"
                                    "system_ids[]=d6bba69a-25a8-11e9-81b8-c85b761454fa"
                                    "&system_ids[]=11b3cbce-25a9-11e9-8457-c85b761454fa",
                                    headers=fixtures.AUTH_HEADER_NO_ACCT)
         self.assertEqual(response.status_code, 400)
 
     def test_comparison_report_duplicate_uuid(self):
-        response = self.client.get("api/drift/v0/comparison_report?"
+        response = self.client.get("api/drift/v1/comparison_report?"
                                    "system_ids[]=d6bba69a-25a8-11e9-81b8-c85b761454fa"
                                    "&system_ids[]=d6bba69a-25a8-11e9-81b8-c85b761454fa",
                                    headers=fixtures.AUTH_HEADER)
         self.assertEqual(response.status_code, 400)
 
-    @mock.patch('drift.views.v0.fetch_systems_with_profiles')
+    @mock.patch('drift.views.v1.fetch_systems_with_profiles')
     def test_comparison_report_api(self, mock_fetch_systems):
         mock_fetch_systems.return_value = fixtures.FETCH_SYSTEMS_WITH_PROFILES_RESULT
-        response = self.client.get("api/drift/v0/comparison_report?"
+        response = self.client.get("api/drift/v1/comparison_report?"
                                    "system_ids[]=d6bba69a-25a8-11e9-81b8-c85b761454fa"
                                    "&system_ids[]=11b3cbce-25a9-11e9-8457-c85b761454fa",
                                    headers=fixtures.AUTH_HEADER)
         self.assertEqual(response.status_code, 200)
 
-    @mock.patch('drift.views.v0.fetch_systems_with_profiles')
+    @mock.patch('drift.views.v1.fetch_systems_with_profiles')
     def test_comparison_report_api_same_facts(self, mock_fetch_systems):
         mock_fetch_systems.return_value = fixtures.FETCH_SYSTEMS_WITH_PROFILES_SAME_FACTS_RESULT
-        response = self.client.get("api/drift/v0/comparison_report?"
+        response = self.client.get("api/drift/v1/comparison_report?"
                                    "system_ids[]=d6bba69a-25a8-11e9-81b8-c85b761454fa"
                                    "&system_ids[]=11b3cbce-25a9-11e9-8457-c85b761454fa",
                                    headers=fixtures.AUTH_HEADER)
         self.assertEqual(response.status_code, 200)
 
-    @mock.patch('drift.views.v0.fetch_systems_with_profiles')
+    @mock.patch('drift.views.v1.fetch_systems_with_profiles')
     def test_comparison_report_api_missing_system_uuid(self, mock_fetch_systems):
         mock_fetch_systems.side_effect = SystemNotReturned("oops")
-        response = self.client.get("api/drift/v0/comparison_report?"
+        response = self.client.get("api/drift/v1/comparison_report?"
                                    "system_ids[]=d6bba69a-25a8-11e9-81b8-c85b761454fa"
                                    "&system_ids[]=11b3cbce-25a9-11e9-8457-c85b761454fa",
                                    headers=fixtures.AUTH_HEADER)
         self.assertEqual(response.status_code, 400)
 
-    @mock.patch('drift.views.v0.fetch_systems_with_profiles')
+    @mock.patch('drift.views.v1.fetch_systems_with_profiles')
     def test_comparison_report_api_500_backend(self, mock_fetch_systems):
         mock_fetch_systems.side_effect = InventoryServiceError("oops")
-        response = self.client.get("api/drift/v0/comparison_report?"
+        response = self.client.get("api/drift/v1/comparison_report?"
                                    "system_ids[]=d6bba69a-25a8-11e9-81b8-c85b761454fa"
                                    "&system_ids[]=11b3cbce-25a9-11e9-8457-c85b761454fa",
                                    headers=fixtures.AUTH_HEADER)
@@ -89,18 +89,18 @@ class DebugLoggingApiTests(unittest.TestCase):
         test_flask_app.logger.addHandler(self.handler)
         test_flask_app.logger.setLevel(logging.DEBUG)
 
-    @mock.patch('drift.views.v0.get_key_from_headers')
+    @mock.patch('drift.views.v1.get_key_from_headers')
     def test_username_logging_on_debug_no_key(self, mock_get_key):
         mock_get_key.return_value = None
-        self.client.get("api/drift/v0/status")
+        self.client.get("api/drift/v1/status")
         self.handler.flush()
         self.assertIn("identity header not sent for request", self.stream.getvalue())
         self.assertNotIn("username from identity header", self.stream.getvalue())
 
-    @mock.patch('drift.views.v0.get_key_from_headers')
+    @mock.patch('drift.views.v1.get_key_from_headers')
     def test_username_logging_on_debug_with_key(self, mock_get_key):
         mock_get_key.return_value = fixtures.AUTH_HEADER['X-RH-IDENTITY']
-        self.client.get("api/drift/v0/status")
+        self.client.get("api/drift/v1/status")
         self.handler.flush()
         self.assertNotIn("identity header not sent for request", self.stream.getvalue())
         self.assertIn("username from identity header: test_user", self.stream.getvalue())


### PR DESCRIPTION
The API is stablized enough to be v1.  The v0 API is no longer supported.