### PR TITLE
rename 'status' to 'state' for nested facts

### DIFF
--- a/drift/info_parser.py
+++ b/drift/info_parser.py
@@ -64,16 +64,16 @@ def _group_comparisons(comparisons):
         else:
             grouped_comparisons.append(comparison)
 
-    # set summary status if grouped comparison contains groups
+    # set summary state if grouped comparison contains groups
     for grouped_comparison in grouped_comparisons:
         if 'comparisons' in grouped_comparison:
             states = {comparison['state'] for comparison in grouped_comparison['comparisons']}
             if COMPARISON_DIFFERENT in states:
-                grouped_comparison['status'] = COMPARISON_DIFFERENT
+                grouped_comparison['state'] = COMPARISON_DIFFERENT
             elif COMPARISON_SAME in states and len(states) == 1:
-                grouped_comparison['status'] = COMPARISON_SAME
+                grouped_comparison['state'] = COMPARISON_SAME
             else:  # use 'incomplete data' as the fallback state if something goes wrong
-                grouped_comparison['status'] = COMPARISON_INCOMPLETE_DATA
+                grouped_comparison['state'] = COMPARISON_INCOMPLETE_DATA
 
     return grouped_comparisons
 

--- a/drift/openapi/api.spec.yaml
+++ b/drift/openapi/api.spec.yaml
@@ -106,7 +106,7 @@ components:
           type: string
         state:
           type: string
-          enum: [SAME, DIFFERENT]
+          enum: [SAME, DIFFERENT, N/A, INCOMPLETE_DATA]
         systems:
           type: array
           items:


### PR DESCRIPTION
Previously, we had the 'state' field incorrectly named as 'status'. We
should be using 'state' everywhere, per the API spec.