### PR TITLE
Add 'N/A' facts to system_profile for display

### DIFF
--- a/drift/constants.py
+++ b/drift/constants.py
@@ -13,6 +13,7 @@ SYSTEM_PROFILE_INTEGERS = {'number_of_cpus', 'number_of_sockets',
                            'cores_per_socket', 'system_memory_bytes'}
 SYSTEM_PROFILE_STRINGS = {'infrastructure_type', 'infrastructure_vendor',
                           'bios_vendor', 'bios_version', 'bios_release_date',
-                          'os_release', 'os_kernel_version', 'arch', 'last_boot_time'}
+                          'os_release', 'os_kernel_version', 'arch', 'last_boot_time',
+                          'cloud_provider'}
 SYSTEM_PROFILE_LISTS_OF_STRINGS_ENABLED = {'cpu_flags', 'kernel_modules', 'enabled_services'}
 SYSTEM_PROFILE_LISTS_OF_STRINGS_INSTALLED = {'installed_services'}

--- a/drift/inventory_service_interface.py
+++ b/drift/inventory_service_interface.py
@@ -6,6 +6,7 @@ from urllib.parse import urljoin
 from drift import config, metrics
 from drift.constants import AUTH_HEADER_NAME, INVENTORY_SVC_SYSTEMS_ENDPOINT
 from drift.constants import INVENTORY_SVC_SYSTEM_PROFILES_ENDPOINT, MAX_UUID_COUNT
+from drift.constants import SYSTEM_PROFILE_INTEGERS, SYSTEM_PROFILE_STRINGS
 from drift.exceptions import SystemNotReturned, InventoryServiceError
 
 
@@ -68,7 +69,18 @@ def fetch_systems_with_profiles(system_ids, service_auth_key, logger):
 
     _ensure_correct_system_count(system_ids, systems_result)
 
-    system_profiles = {profile['id']: profile for profile in system_profiles_result['results']}
+    # create a blank profile for each system
+    system_profiles = {system['id']: {'system_profile': {}} for system in systems_result['results']}
+    # update with actual profile info if we have it
+    system_profiles.update({profile['id']: profile
+                            for profile in system_profiles_result['results']})
+
+    # fill in any fields that were not on the profile
+    for system_id in system_profiles:
+        # TODO: populate more than just integers and strings
+        for key in SYSTEM_PROFILE_INTEGERS | SYSTEM_PROFILE_STRINGS:
+            if key not in system_profiles[system_id]['system_profile']:
+                system_profiles[system_id]['system_profile'][key] = 'N/A'
 
     systems_with_profiles = []
     for system in systems_result['results']:
@@ -76,12 +88,11 @@ def fetch_systems_with_profiles(system_ids, service_auth_key, logger):
         # we do not use the 'facts' field
         system_with_profile.pop('facts', None)
 
-        if system['id'] in system_profiles:
-            system_with_profile['system_profile'] = system_profiles[system['id']]['system_profile']
-            # we duplicate a bit of metadata in the inner dict to make parsing easier
-            system_with_profile['system_profile']['id'] = system['id']
-            system_with_profile['system_profile']['fqdn'] = system['fqdn']
-            system_with_profile['system_profile']['updated'] = system['updated']
+        system_with_profile['system_profile'] = system_profiles[system['id']]['system_profile']
+        # we duplicate a bit of metadata in the inner dict to make parsing easier
+        system_with_profile['system_profile']['id'] = system['id']
+        system_with_profile['system_profile']['fqdn'] = system['fqdn']
+        system_with_profile['system_profile']['updated'] = system['updated']
 
         systems_with_profiles.append(system_with_profile)
 


### PR DESCRIPTION
Previously, if a system was missing a piece of info like `cpu_count`,
we would not display it. This could happen if all of the systems being
compared did not have the fact.

Instead, display with `N/A` as the value.