### PR TITLE
Fix grouped facts display for incomplete data

### DIFF
--- a/drift/openapi/api.spec.yaml
+++ b/drift/openapi/api.spec.yaml
@@ -95,7 +95,11 @@ components:
                     for displaying rows of facts to compare. Note that if the
                     'comparisons' array is populated, the 'system' field
                     will not be used. The 'comparisons' array is used for
-                    creating nested values."
+                    creating nested values.
+                    If a fact for one system is N/A, it will make the entire
+                    status N/A. However, if facts are being grouped and one
+                    fact is in DIFFERENT state, then the group's roll-up status
+                    will be DIFFERENT."
       required:
         - name
         - state


### PR DESCRIPTION
fact comparison status is supposed to work like this:

* if any fact is N/A, use "incomplete data" status
* if any fact is different, use "different" status
* if all facts are the same, use "same" status
* otherwise, use "incomplete data" (fallback state)

This commit changes the grouped facts behavior to match the way
per-system fact comparison works. Without this PR, if any fact was in
"different" status, the grouping would show as different even if there
were also N/A facts.