### PR TITLE
Paginate responses when calling inventory service

### DIFF
--- a/drift/constants.py
+++ b/drift/constants.py
@@ -1,8 +1,7 @@
 AUTH_HEADER_NAME = 'X-RH-IDENTITY'
 FACT_NAMESPACE = "system_profile"
-INVENTORY_SVC_SYSTEMS_ENDPOINT = '/api/inventory/v1/hosts/%s?per_page=%s'
-INVENTORY_SVC_SYSTEM_PROFILES_ENDPOINT = '/api/inventory/v1/hosts/%s/system_profile?per_page=%s'
-MAX_UUID_COUNT = 20
+INVENTORY_SVC_SYSTEMS_ENDPOINT = '/api/inventory/v1/hosts/%s'
+INVENTORY_SVC_SYSTEM_PROFILES_ENDPOINT = '/api/inventory/v1/hosts/%s/system_profile'
 SYSTEM_ID_KEY = 'id'
 
 COMPARISON_SAME = "SAME"

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -145,6 +145,7 @@ FETCH_SYSTEMS_WITH_PROFILES_RESULT = [
 FETCH_SYSTEM_PROFILES_INV_SVC = '''
 {
   "count": 1,
+  "total": 1,
   "page": 1,
   "per_page": 50,
   "results": [
@@ -265,6 +266,7 @@ FETCH_SYSTEMS_WITH_PROFILES_SAME_FACTS_RESULT = [
 FETCH_SYSTEMS_INV_SVC = '''
     {
       "count": 2,
+      "total": 2,
       "page": 1,
       "per_page": 50,
       "results": [

--- a/tests/test_inventory_service_interface.py
+++ b/tests/test_inventory_service_interface.py
@@ -1,6 +1,5 @@
 import requests
 import responses
-import string
 import unittest
 import mock
 
@@ -24,7 +23,7 @@ class InventoryServiceTests(unittest.TestCase):
                       content_type='application/json')
 
     def _create_response_for_system_profiles(self, service_hostname, system_uuids):
-        url_template = "http://%s/api/inventory/v1/hosts/%s/system_profile?per_page=20"
+        url_template = "http://%s/api/inventory/v1/hosts/%s/system_profile?page=1&per_page=20"
         responses.add(responses.GET, url_template % (service_hostname, system_uuids),
                       body=fixtures.FETCH_SYSTEM_PROFILES_INV_SVC, status=requests.codes.ok,
                       content_type='application/json')
@@ -36,7 +35,7 @@ class InventoryServiceTests(unittest.TestCase):
                       content_type='application/json')
 
     def _create_500_response_for_system_profiles(self, service_hostname, system_uuids):
-        url_template = "http://%s/api/inventory/v1/hosts/%s/system_profile?per_page=20"
+        url_template = "http://%s/api/inventory/v1/hosts/%s/system_profile?page=1&per_page=20"
         responses.add(responses.GET, url_template % (service_hostname, system_uuids),
                       body="I am error", status=requests.codes.INTERNAL_SERVER_ERROR,
                       content_type='application/json')
@@ -96,13 +95,3 @@ class InventoryServiceTests(unittest.TestCase):
 
         self.assertEqual(cm.exception.message,
                          "Error received from backend service")
-
-    def test_fetch_too_many_systems(self):
-        systems_to_fetch = list(string.ascii_lowercase)
-
-        with self.assertRaises(SystemNotReturned) as cm:
-            inventory_service_interface.fetch_systems_with_profiles(systems_to_fetch, "my-auth-key",
-                                                                    self.mock_logger)
-
-        self.assertEqual(cm.exception.message,
-                         "Too many systems requested, limit is 20")


### PR DESCRIPTION
Previously we limited the number of hosts to compare to 20. This
commit removes that limit, but still calls inventory service in
batches of 20.