### PR TITLE
record system report metrics

### DIFF
--- a/drift/inventory_service_interface.py
+++ b/drift/inventory_service_interface.py
@@ -95,6 +95,7 @@ def fetch_systems_with_profiles(system_ids, service_auth_key, logger):
     system_profiles.update({profile['id']: profile
                             for profile in system_profiles_result})
 
+    systems_without_profile_count = 0
     # fill in any fields that were not on the profile
     for system_id in system_profiles:
         # before we populate the fields, mark where the system profile came
@@ -104,10 +105,14 @@ def fetch_systems_with_profiles(system_ids, service_auth_key, logger):
             system_profiles[system_id]['system_profile']['system_profile_exists'] = True
         else:
             system_profiles[system_id]['system_profile']['system_profile_exists'] = False
+            systems_without_profile_count += 1
         # TODO: populate more than just integers and strings
         for key in SYSTEM_PROFILE_INTEGERS | SYSTEM_PROFILE_STRINGS:
             if key not in system_profiles[system_id]['system_profile']:
                 system_profiles[system_id]['system_profile'][key] = 'N/A'
+
+    # record how many no-profile systems were in this report
+    metrics.systems_compared_no_sysprofile.observe(systems_without_profile_count)
 
     systems_with_profiles = []
     for system in systems_result:

--- a/drift/metrics.py
+++ b/drift/metrics.py
@@ -3,6 +3,15 @@ from prometheus_client import Counter, Histogram
 api_exceptions = Counter("drift_inventory_service_exceptions",
                          "count of exceptions raised on public API")
 
+systems_compared = Histogram("drift_systems_compared",
+                             "count of systems compared in each request",
+                             buckets=[2, 4, 8, 16, 32, 64, 128, 256])
+
+systems_compared_no_sysprofile = Histogram("drift_systems_compared_no_sysprofile",
+                                           "count of systems without system profile"
+                                           "compared in each request",
+                                           buckets=[2, 4, 8, 16, 32, 64, 128, 256])
+
 comparison_report_requests = Histogram("drift_comparison_report_requests",
                                        "comparison report request stats")
 

--- a/drift/views/v1.py
+++ b/drift/views/v1.py
@@ -39,6 +39,7 @@ def comparison_report(system_ids, auth_key):
         comparisons = info_parser.build_comparisons(fetch_systems_with_profiles(system_ids,
                                                                                 auth_key,
                                                                                 current_app.logger))
+        metrics.systems_compared.observe(len(system_ids))
         return jsonify(comparisons)
     except SystemNotReturned as error:
         raise HTTPError(HTTPStatus.BAD_REQUEST, message=error.message)


### PR DESCRIPTION
Record the number of systems compared and number of systems with no
profile in each report. This is useful for learning how users are
using the app.