### PR TITLE
do not use dict update

### DIFF
--- a/drift/info_parser.py
+++ b/drift/info_parser.py
@@ -117,17 +117,15 @@ def _parse_profile(system_profile):
         """
         for list_of_strings in names:
             for item in system_profile.get(list_of_strings, []):
-                parsed_profile.update({list_of_strings + '.' + item: verb})
+                parsed_profile[list_of_strings + '.' + item] = verb
 
     def _parse_yum_repo(name):
         """
         helper method to convert yum repo objects to comparable facts
         """
-        parsed_profile.update({'yum_repos.' + name + '.base_url': yum_repo.get('base_url', 'N/A')})
-        parsed_profile.update({'yum_repos.' + name + '.enabled':
-                               str(yum_repo.get('enabled', 'N/A'))})
-        parsed_profile.update({'yum_repos.' + name + '.gpgcheck':
-                               str(yum_repo.get('gpgcheck', 'N/A'))})
+        parsed_profile['yum_repos.' + name + '.base_url'] = yum_repo.get('base_url', 'N/A')
+        parsed_profile['yum_repos.' + name + '.enabled'] = str(yum_repo.get('enabled', 'N/A'))
+        parsed_profile['yum_repos.' + name + '.gpgcheck'] = str(yum_repo.get('gpgcheck', 'N/A'))
 
     def _canonicalize_ipv6_addr(addr):
         """
@@ -145,28 +143,25 @@ def _parse_profile(system_profile):
         """
         ipv6_addresses = [_canonicalize_ipv6_addr(addr)
                           for addr in interface.get('ipv6_addresses', ['N/A'])]
-        parsed_profile.update({'network_interfaces.' + name + '.ipv4_addresses':
-                               ','.join(interface.get('ipv4_addresses', ['N/A']))})
-        parsed_profile.update({'network_interfaces.' + name + '.ipv6_addresses':
-                               ','.join(ipv6_addresses)})
-        parsed_profile.update({'network_interfaces.' + name + '.mac_address':
-                               interface.get('mac_address', 'N/A')})
-        parsed_profile.update({'network_interfaces.' + name + '.mtu': interface.get('mtu', 'N/A')})
-        parsed_profile.update({'network_interfaces.' + name + '.state':
-                               interface.get('state', 'N/A')})
-        parsed_profile.update({'network_interfaces.' + name + '.type':
-                               interface.get('loopback', 'N/A')})
+        parsed_profile['network_interfaces.' + name + '.ipv4_addresses'] = \
+            ','.join(interface.get('ipv4_addresses', ['N/A']))
+        parsed_profile['network_interfaces.' + name + '.ipv6_addresses'] = \
+            ','.join(ipv6_addresses)
+        parsed_profile['network_interfaces.' + name + '.mac_address'] = \
+            interface.get('mac_address', 'N/A')
+        parsed_profile['network_interfaces.' + name + '.mtu'] = interface.get('mtu', 'N/A')
+        parsed_profile['network_interfaces.' + name + '.state'] = interface.get('state', 'N/A')
+        parsed_profile['network_interfaces.' + name + '.type'] = interface.get('loopback', 'N/A')
 
     # start with metadata that we have brought down from the system record
     parsed_profile = {'id': system_profile[SYSTEM_ID_KEY]}
     # add all strings as-is
-    parsed_profile.update({key: system_profile.get(key, None) for key in SYSTEM_PROFILE_STRINGS})
+    for key in SYSTEM_PROFILE_STRINGS:
+        parsed_profile[key] = system_profile.get(key, None)
 
     # add all integers, converting to str
-    parsed_profile.update({key: str(system_profile.get(key, None))
-                           for key in SYSTEM_PROFILE_INTEGERS})
-    parsed_profile.update({key: str(system_profile.get(key, None))
-                           for key in SYSTEM_PROFILE_BOOLEANS})
+    for key in SYSTEM_PROFILE_INTEGERS | SYSTEM_PROFILE_BOOLEANS:
+        parsed_profile[key] = str(system_profile.get(key, None))
 
     _parse_lists_of_strings(SYSTEM_PROFILE_LISTS_OF_STRINGS_ENABLED, 'enabled')
     _parse_lists_of_strings(SYSTEM_PROFILE_LISTS_OF_STRINGS_INSTALLED, 'installed')
@@ -181,7 +176,7 @@ def _parse_profile(system_profile):
     for package in system_profile.get('installed_packages', []):
         try:
             name, vra = _get_name_vra_from_string(package)
-            parsed_profile.update({'installed_packages.' + name: vra})
+            parsed_profile['installed_packages.' + name] = vra
         except UnparsableNEVRAError as e:
             current_app.logger.warn(e.message)
 

--- a/drift/inventory_service_interface.py
+++ b/drift/inventory_service_interface.py
@@ -92,8 +92,8 @@ def fetch_systems_with_profiles(system_ids, service_auth_key, logger):
     # create a blank profile for each system
     system_profiles = {system['id']: {'system_profile': {}} for system in systems_result}
     # update with actual profile info if we have it
-    system_profiles.update({profile['id']: profile
-                            for profile in system_profiles_result})
+    for profile in system_profiles_result:
+        system_profiles[profile['id']] = profile
 
     systems_without_profile_count = 0
     # fill in any fields that were not on the profile


### PR DESCRIPTION
Previously, we were using `update()` a lot for setting values on
dicts.  This requires creating a dictionary, then merging with
another.

Instead, we can just set keys directly.

This commit should not change functionality at all.