### PR TITLE
properly name exceptions metrics

### DIFF
--- a/drift/inventory_service_interface.py
+++ b/drift/inventory_service_interface.py
@@ -44,7 +44,8 @@ def _fetch_url(url, auth_header, logger):
     """
     logger.debug("fetching %s" % url)
     with metrics.inventory_service_requests.time():
-        response = requests.get(url, headers=auth_header)
+        with metrics.inventory_service_exceptions.count_exceptions():
+            response = requests.get(url, headers=auth_header)
     logger.debug("fetched %s" % url)
     _validate_inventory_response(response, logger)
     return response.json()

--- a/drift/metrics.py
+++ b/drift/metrics.py
@@ -1,6 +1,9 @@
 from prometheus_client import Counter, Histogram
 
-api_exceptions = Counter("drift_inventory_service_exceptions",
+inventory_service_exceptions = Counter("drift_inventory_service_exceptions",
+                                       "count of exceptions raised by inv service")
+
+api_exceptions = Counter("drift_api_exceptions",
                          "count of exceptions raised on public API")
 
 systems_compared = Histogram("drift_systems_compared",


### PR DESCRIPTION
Previously, I had wires crossed and was counting our exceptions
as inv service exceptions (oops!).

This commit uncrosses the wires.