### PR TITLE
add WEB_CONCURRENCY env var

### DIFF
--- a/openshift/roles/drift-backend/templates/deployment-config.yaml
+++ b/openshift/roles/drift-backend/templates/deployment-config.yaml
@@ -42,6 +42,8 @@ spec:
               value: "{{ inventory_svc_url }}"
             - name: CW_LOG_GROUP
               value: "{{ cloudwatch_log_group }}"
+            - name: WEB_CONCURRENCY
+              value: 4
             - name: AWS_REGION
               value: 'us-east-1'
             - name: CW_AWS_ACCESS_KEY_ID


### PR DESCRIPTION
This var was previously not set, which resulted in the number of
workers being set by counting the number of CPUs. This resulted in
memory issues if too many workers spun up.

The number of workers is now capped at 4.