### PR TITLE
replace None with N/A

### DIFF
--- a/drift/info_parser.py
+++ b/drift/info_parser.py
@@ -304,7 +304,7 @@ def _create_comparison(systems, info_name):
         {
             "id": system[SYSTEM_ID_KEY],
             "name": system["name"],
-            "value": system.get(info_name, "N/A"),
+            "value": system.get(info_name, "N/A") or "N/A",
         }
         for system in systems
     ]


### PR DESCRIPTION
It was possible for some facts (specifically fqdn) to be None. The
check to display 'N/A' was only checking if a fact was undefined, not
if it was actually None.

The 'N/A' subsitution will now convert None to 'N/A' as well as
undefined facts.