### PR TITLE
handle empty lists from baseline service

### DIFF
--- a/drift/baseline_service_interface.py
+++ b/drift/baseline_service_interface.py
@@ -1,7 +1,7 @@
 from urllib.parse import urljoin
 
 from drift import config, metrics
-from drift.service_interface import fetch_data
+from drift.service_interface import fetch_data, ensure_correct_count
 from drift.constants import AUTH_HEADER_NAME, BASELINE_SVC_ENDPOINT
 
 
@@ -22,5 +22,6 @@ def fetch_baselines(baseline_ids, service_auth_key, logger):
         metrics.baseline_service_requests,
         metrics.baseline_service_exceptions,
     )
+    ensure_correct_count(baseline_ids, baseline_result)
 
     return baseline_result

--- a/drift/exceptions.py
+++ b/drift/exceptions.py
@@ -17,12 +17,12 @@ class HTTPError(Exception):
         self.status_code = status_code
 
 
-class SystemNotReturned(Exception):
+class ItemNotReturned(Exception):
     def __init__(self, message):
         """
-        Raise this exception if a system was not returned by inventory service
+        Raise this exception if an item was not returned by inventory service
         """
-        super(SystemNotReturned, self).__init__()
+        super(ItemNotReturned, self).__init__()
         self.message = message
 
 

--- a/drift/info_parser.py
+++ b/drift/info_parser.py
@@ -124,7 +124,14 @@ def _select_applicable_info(systems_with_profiles, baselines):
     for baseline in baselines:
         baseline_facts = {"id": baseline["id"], "name": baseline["display_name"]}
         for baseline_fact in baseline["baseline_facts"]:
-            baseline_facts[baseline_fact["name"]] = baseline_fact["value"]
+            if "value" in baseline_fact:
+                baseline_facts[baseline_fact["name"]] = baseline_fact["value"]
+            elif "values" in baseline_fact:
+                prefix = baseline_fact["name"]
+                for nested_fact in baseline_fact["values"]:
+                    baseline_facts[prefix + "." + nested_fact["name"]] = nested_fact[
+                        "value"
+                    ]
         parsed_system_profiles.append(baseline_facts)
 
     # find the set of all keys to iterate over

--- a/drift/inventory_service_interface.py
+++ b/drift/inventory_service_interface.py
@@ -4,22 +4,7 @@ from drift import config, metrics
 from drift.constants import AUTH_HEADER_NAME, INVENTORY_SVC_SYSTEMS_ENDPOINT
 from drift.constants import INVENTORY_SVC_SYSTEM_PROFILES_ENDPOINT
 from drift.constants import SYSTEM_PROFILE_INTEGERS, SYSTEM_PROFILE_STRINGS
-from drift.exceptions import SystemNotReturned
-from drift.service_interface import fetch_data
-
-
-def _ensure_correct_system_count(system_ids_requested, result):
-    """
-    raise an exception if we didn't get back the number of systems we expected.
-
-    If the count is correct, do nothing.
-    """
-    if len(result) < len(system_ids_requested):
-        system_ids_returned = {system["id"] for system in result}
-        missing_ids = set(system_ids_requested) - system_ids_returned
-        raise SystemNotReturned(
-            "System(s) %s not available to display" % ",".join(missing_ids)
-        )
+from drift.service_interface import fetch_data, ensure_correct_count
 
 
 def fetch_systems_with_profiles(system_ids, service_auth_key, logger):
@@ -54,7 +39,7 @@ def fetch_systems_with_profiles(system_ids, service_auth_key, logger):
         metrics.inventory_service_exceptions,
     )
 
-    _ensure_correct_system_count(system_ids, systems_result)
+    ensure_correct_count(system_ids, systems_result)
 
     # create a blank profile for each system
     system_profiles = {

--- a/drift/service_interface.py
+++ b/drift/service_interface.py
@@ -1,7 +1,7 @@
 import requests
 
 from drift.constants import AUTH_HEADER_NAME
-from drift.exceptions import ServiceError
+from drift.exceptions import ItemNotReturned, ServiceError
 
 
 def get_key_from_headers(incoming_headers):
@@ -33,6 +33,18 @@ def _fetch_url(url, auth_header, logger, time_metric, exception_metric):
     logger.debug("fetched %s" % url)
     _validate_service_response(response, logger)
     return response.json()
+
+
+def ensure_correct_count(ids_requested, result):
+    """
+    raise an exception if we didn't get back the number of items we expected.
+
+    If the count is correct, do nothing.
+    """
+    if len(result) < len(ids_requested):
+        ids_returned = {item["id"] for item in result}
+        missing_ids = set(ids_requested) - ids_returned
+        raise ItemNotReturned("%s not available to display" % ",".join(missing_ids))
 
 
 def fetch_data(url, auth_header, object_ids, logger, time_metric, exception_metric):

--- a/drift/views/v1.py
+++ b/drift/views/v1.py
@@ -6,7 +6,7 @@ import base64
 from uuid import UUID
 
 from drift import info_parser, metrics
-from drift.exceptions import HTTPError, SystemNotReturned
+from drift.exceptions import HTTPError, ItemNotReturned
 from drift.inventory_service_interface import fetch_systems_with_profiles
 from drift.service_interface import get_key_from_headers
 from drift.baseline_service_interface import fetch_baselines
@@ -48,7 +48,7 @@ def comparison_report(system_ids, baseline_ids, auth_key):
         )
         metrics.systems_compared.observe(len(system_ids))
         return jsonify(comparisons)
-    except SystemNotReturned as error:
+    except ItemNotReturned as error:
         raise HTTPError(HTTPStatus.BAD_REQUEST, message=error.message)
 
 

--- a/tests/test_inventory_service_interface.py
+++ b/tests/test_inventory_service_interface.py
@@ -4,7 +4,7 @@ import unittest
 import mock
 
 from drift import app, inventory_service_interface
-from drift.exceptions import ServiceError, SystemNotReturned
+from drift.exceptions import ServiceError, ItemNotReturned
 from . import fixtures
 
 
@@ -91,14 +91,14 @@ class InventoryServiceTests(unittest.TestCase):
             "inventory_svc_url_is_not_set", ",".join(systems_to_fetch)
         )
 
-        with self.assertRaises(SystemNotReturned) as cm:
+        with self.assertRaises(ItemNotReturned) as cm:
             inventory_service_interface.fetch_systems_with_profiles(
                 systems_to_fetch, "my-auth-key", self.mock_logger
             )
 
         self.assertEqual(
             cm.exception.message,
-            "System(s) 269a3da8-262f-11e9-8ee5-c85b761454fa not available to display",
+            "269a3da8-262f-11e9-8ee5-c85b761454fa not available to display",
         )
 
     @responses.activate

--- a/tests/test_v1_api.py
+++ b/tests/test_v1_api.py
@@ -2,7 +2,7 @@ from io import StringIO
 import logging
 
 from drift import app
-from drift.exceptions import ServiceError, SystemNotReturned
+from drift.exceptions import ServiceError, ItemNotReturned
 
 from . import fixtures
 import mock
@@ -109,7 +109,7 @@ class ApiTests(unittest.TestCase):
 
     @mock.patch("drift.views.v1.fetch_systems_with_profiles")
     def test_comparison_report_api_missing_system_uuid(self, mock_fetch_systems):
-        mock_fetch_systems.side_effect = SystemNotReturned("oops")
+        mock_fetch_systems.side_effect = ItemNotReturned("oops")
         response = self.client.get(
             "api/drift/v1/comparison_report?"
             "system_ids[]=d6bba69a-25a8-11e9-81b8-c85b761454fa"


### PR DESCRIPTION
Previously, if you asked for a comparison report with a baseline that
was unavailable, the call would return a 500.

Instead, return a 400 with an error message.