### PR TITLE
move x-rh-identity header and increase validation

### DIFF
--- a/drift/app.py
+++ b/drift/app.py
@@ -20,7 +20,9 @@ def create_app():
     connexion_app = connexion.App(
         __name__, specification_dir="openapi/", arguments=openapi_args
     )
-    connexion_app.add_api("api.spec.yaml")
+    connexion_app.add_api(
+        "api.spec.yaml", validate_responses=True, strict_validation=True
+    )
     connexion_app.add_api("mgmt_api.spec.yaml")
     flask_app = connexion_app.app
 

--- a/drift/openapi/api.spec.yaml
+++ b/drift/openapi/api.spec.yaml
@@ -13,8 +13,6 @@ servers:
 
 paths:
   /comparison_report:
-    parameters:
-      - $ref: '#/components/parameters/rhIdentityHeader'
     get:
       summary: fetch comparison report
       description: "Fetch a comparison report for given system IDs. This will
@@ -89,6 +87,12 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Error"
+  securitySchemes:
+    ApiKeyAuth:
+      description: "Identity header provided by 3scale"
+      in: "header"
+      name: "x-rh-identity"
+      type: "apiKey"
   schemas:
     ComparisonRequest:
       required:
@@ -188,14 +192,3 @@ components:
         last_updated:
           type: string
           format: date-time
-  parameters:
-    rhIdentityHeader:
-      in: header
-      name: x-rh-identity
-      required: true
-      schema:
-        type: string
-      description: "Base64-encoded JSON identity header provided by 3Scale.
-                    Contains an account number of the user issuing the
-                    request. Format of the JSON:
-                    {'identity': {'account_number': '12345678'}}"


### PR DESCRIPTION
The `x-rh-identity` header was previously defined as an API parameter.
This caused issues with autogeneration of API bindings.

Instead, move the header's definition to a security scheme.

This PR also enables `strict_validation` and `validate_responses` on
the API. The API appeared to already be in spec and no additional
changes were required besides enabling these additional validators.