### PR TITLE
fix: disallow duplicate baseline ids in request

### DIFF
--- a/drift/views/v1.py
+++ b/drift/views/v1.py
@@ -117,6 +117,12 @@ def comparison_report(
             message="duplicate UUID specified in system_ids list",
         )
 
+    if len(baseline_ids) > len(set(baseline_ids)):
+        raise HTTPError(
+            HTTPStatus.BAD_REQUEST,
+            message="duplicate UUID specified in baseline_ids list",
+        )
+
     _validate_uuids(system_ids)
     _validate_uuids(baseline_ids)
 

--- a/tests/test_v1_api.py
+++ b/tests/test_v1_api.py
@@ -83,6 +83,16 @@ class ApiTests(unittest.TestCase):
         )
         self.assertEqual(response.status_code, 400)
 
+    def test_comparison_report_duplicate_baseline_uuid(self):
+        response = self.client.get(
+            "api/drift/v1/comparison_report?"
+            "system_ids[]=d6bba69a-25a8-11e9-81b8-c85b761454fa"
+            "&baseline_ids[]=ac05734a-6d46-11ea-b0f0-54e1add9c7a0"
+            "&baseline_ids[]=ac05734a-6d46-11ea-b0f0-54e1add9c7a0",
+            headers=fixtures.AUTH_HEADER,
+        )
+        self.assertEqual(response.status_code, 400)
+
     def test_comparison_report_bad_uuid(self):
         response = self.client.get(
             "api/drift/v1/comparison_report?"


### PR DESCRIPTION
previously we did not raise an error for same baseline id given twice
now we return a 400 error