### PR TITLE
fix: unswap reference_id and auth_key

### DIFF
--- a/drift/views/v1.py
+++ b/drift/views/v1.py
@@ -174,12 +174,12 @@ def comparison_report_get():
         data_format = "csv"
 
     return comparison_report(
-        system_ids,
-        baseline_ids,
-        historical_sys_profile_ids,
-        auth_key,
-        reference_id,
-        data_format,
+        system_ids=system_ids,
+        baseline_ids=baseline_ids,
+        historical_sys_profile_ids=historical_sys_profile_ids,
+        reference_id=reference_id,
+        auth_key=auth_key,
+        data_format=data_format,
     )
 
 
@@ -201,12 +201,12 @@ def comparison_report_post():
         data_format = "csv"
 
     return comparison_report(
-        system_ids,
-        baseline_ids,
-        historical_sys_profile_ids,
-        reference_id,
-        auth_key,
-        data_format,
+        system_ids=system_ids,
+        baseline_ids=baseline_ids,
+        historical_sys_profile_ids=historical_sys_profile_ids,
+        reference_id=reference_id,
+        auth_key=auth_key,
+        data_format=data_format,
     )
 
 


### PR DESCRIPTION
I transposed two values when calling `comparison_report`, which caused
GET to fail.

This commit adds named parameters to the `comparison_report` fetching
so the bug does not happen again.