### PR TITLE
[DRFT-155] Change No Data to empty string for multivalue

### DIFF
--- a/drift/info_parser.py
+++ b/drift/info_parser.py
@@ -366,7 +366,7 @@ def _create_comparison(systems, info_name, reference_id, system_count):
                     if sorted_all_value_options[row] == value:
                         column.append(value)
                     else:
-                        column.append(None)
+                        column.append("")
                         info_comparison = COMPARISON_DIFFERENT
                         multivalue_comparisons[row] = COMPARISON_DIFFERENT
                     row += 1
@@ -375,7 +375,7 @@ def _create_comparison(systems, info_name, reference_id, system_count):
                     if sorted_all_value_options[row] in value:
                         column.append(sorted_all_value_options[row])
                     else:
-                        column.append(None)
+                        column.append("")
                         info_comparison = COMPARISON_DIFFERENT
                         multivalue_comparisons[row] = COMPARISON_DIFFERENT
                     row += 1


### PR DESCRIPTION
Make multivalue facts display the same way as the rest of the comparison report with empty cells in stead of "No Data".

Feel free to discuss here any special cases such as Tags and how you'd like them to be addressed, or we can open that as a bug/separate ticket, either is fine with me.