### PR TITLE
[DRFT-1137] Change Sort method

### DIFF
--- a/drift/info_parser.py
+++ b/drift/info_parser.py
@@ -99,7 +99,7 @@ def build_comparisons(
         grouped_comparisons = _group_comparisons(stripped_comparisons)
 
     with PT_BC_SORT_COMPARISONS.time():
-        sorted_comparisons = sorted(grouped_comparisons, key=lambda comparison: comparison["name"])
+        grouped_comparisons.sort(key=lambda comparison: comparison["name"])
 
     with PT_BC_CREATE_METADATA.time():
         # create metadata
@@ -112,22 +112,19 @@ def build_comparisons(
             _system_mapping(system_with_profile) for system_with_profile in systems_with_profiles
         ]
         with PT_BC_SORT_SYSTEM_MAPPINGS.time():
-            sorted_system_mappings = sorted(
-                system_mappings, key=lambda system: system["display_name"]
-            )
+            system_mappings.sort(key=lambda system: system["display_name"])
 
         with PT_BC_SORT_HSP.time():
-            sorted_historical_sys_profile_mappings = sorted(
-                historical_sys_profile_mappings,
+            historical_sys_profile_mappings.sort(
                 key=lambda hsp: dateparse(hsp["updated"]),
                 reverse=True,
             )
 
     return {
-        "facts": sorted_comparisons,
-        "systems": sorted_system_mappings,
+        "facts": grouped_comparisons,
+        "systems": system_mappings,
         "baselines": baseline_mappings,
-        "historical_system_profiles": sorted_historical_sys_profile_mappings,
+        "historical_system_profiles": historical_sys_profile_mappings,
         "drift_event_notify": drift_event_notify,
     }
 


### PR DESCRIPTION
That's my #1 (First) attempt to change sort method.. changing from `sorted()` to `.sort()`

after read tons of links, here what I found:

`sort()` is a method of the list class, and sorts the list in-place, returning None.
`sorted()` is a method built into the Python namespace, and sorts the list out-of-place, returning a sorted copy of the list, without affecting the original one.

in my tests, `sorted()` is more fast in small number of objects, but in large objects `sort` is more fast, something like this:

```
<100 elements, pretty much the same  ~0.5s
>=100 <1000 elements, `sort()` takes **half** of the time
>=1000 elements, `sorted()` takes nearly ten times as much computation time as `sort()` does.
```


## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
