### PR TITLE
fix(DRFT-1361): Fix comparison bug for systemd fact

### DIFF
--- a/drift/info_parser.py
+++ b/drift/info_parser.py
@@ -322,7 +322,9 @@ def _create_comparison(systems, info_name, reference_id, system_count, short_cir
         {
             "id": system[SYSTEM_ID_KEY],
             "name": system["name"],
-            "value": system.get(info_name, "N/A") or "N/A",
+            "value": "N/A"
+            if system.get(info_name, "N/A") is None
+            else str(system.get(info_name, "N/A")),
             "is_obfuscated": system.get("obfuscation", {}).get(info_name, False),
             "is_baseline": system["is_baseline"],
         }

--- a/tests/test_info_parser.py
+++ b/tests/test_info_parser.py
@@ -49,3 +49,4 @@ class InfoParserTests(unittest.TestCase):
         fake_plastic_tree = MagicMock()
         result = profile_parser.parse_profile(profile, "some_display_name", fake_plastic_tree)
         self.assertEqual(result["systemd.state"], "running")
+        self.assertEqual(result["systemd.failed"], 0)


### PR DESCRIPTION
This PR fix a bug when the system fact value is `0` or None.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
