### PR TITLE
feat(RHINENG-6114): Allow ServiceAccount type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ prometheus_client = "*"
 watchtower = "*"
 python-dateutil = "*"
 unleashclient = "*"
-kerlescan = {git = "https://github.com/RedHatInsights/kerlescan.git", rev = "0.114", develop = true}
+kerlescan = {git = "https://github.com/RedHatInsights/kerlescan.git", rev = "0.115", develop = true}
 
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -111,6 +111,42 @@ AUTH_HEADER_NO_ACCT = {
     "JpbnRlcm5hbCI6eyJvcmdfaWQiOiI5OTk5In19fQo="
 }
 
+
+"""
+decoded AUTH_HEADER_SERVICE_ACCOUNT (newlines added for readablity):
+{
+  "entitlements": {},
+  "identity": {
+    "auth_type": "jwt-auth",
+    "internal": {
+      "auth_time": 500,
+      "cross_access": false,
+      "org_id": "9999"
+    },
+    "org_id": "9999",
+    "service_account": {
+      "client_id": "b69eaf9e-e6a6-4f9e-805e-02987daddfxd",
+      "username": "service-account-b69eaf9e-e6a6-4f9e-805e-02987daddfxd"
+    },
+    "type": "ServiceAccount"
+  }
+}
+"""
+
+AUTH_HEADER_SERVICE_ACCOUNT = {
+    "X-RH-IDENTITY": "ewogICJlbnRpdGxlbWVudHMiOiB7fSwKICAiaWRlbnRpdHki"
+    "OiB7CiAgICAiYXV0aF90eXBlIjogImp3dC1hdXRoIiwKICAg"
+    "ICJpbnRlcm5hbCI6IHsKICAgICAgImF1dGhfdGltZSI6IDUwM"
+    "CwKICAgICAgImNyb3NzX2FjY2VzcyI6IGZhbHNlLAogICAgI"
+    "CAib3JnX2lkIjogIjk5OTkiCiAgICB9LAogICAgIm9yZ19pZ"
+    "CI6ICI5OTk5IiwKICAgICJzZXJ2aWNlX2FjY291bnQiOiB7C"
+    "iAgICAgICJjbGllbnRfaWQiOiAiYjY5ZWFmOWUtZTZhNi00Z"
+    "jllLTgwNWUtMDI5ODdkYWRkZnhkIiwKICAgICAgInVzZXJuYW"
+    "1lIjogInNlcnZpY2UtYWNjb3VudC1iNjllYWY5ZS1lNmE2LT"
+    "RmOWUtODA1ZS0wMjk4N2RhZGRmeGQiCiAgICB9LAogICAgIn"
+    "R5cGUiOiAiU2VydmljZUFjY291bnQiCiAgfQp9"
+}
+
 FETCH_BASELINES_RESULT = [
     {
         "id": "ff35596c-f98e-11e9-aea9-98fa9b07d419",

--- a/tests/test_v1_api.py
+++ b/tests/test_v1_api.py
@@ -239,6 +239,17 @@ class ApiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
 
     @mock.patch("drift.views.v1.fetch_systems_with_profiles")
+    def test_comparison_report_api_with_service_account_identity(self, mock_fetch_systems):
+        mock_fetch_systems.return_value = fixtures.FETCH_SYSTEMS_WITH_PROFILES_SAME_FACTS_RESULT
+        response = self.client.get(
+            "api/drift/v1/comparison_report?"
+            "system_ids[]=d6bba69a-25a8-11e9-81b8-c85b761454fa"
+            "&system_ids[]=11b3cbce-25a9-11e9-8457-c85b761454fa",
+            headers=fixtures.AUTH_HEADER_SERVICE_ACCOUNT,
+        )
+        self.assertEqual(response.status_code, 200)
+
+    @mock.patch("drift.views.v1.fetch_systems_with_profiles")
     def test_comparison_report_api_missing_system_uuid(self, mock_fetch_systems):
         mock_fetch_systems.side_effect = ItemNotReturned("oops")
         response = self.client.get(


### PR DESCRIPTION
Allow `ServiceAccount` type to reach out drift endpoints

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
